### PR TITLE
Fixes to style on mobile

### DIFF
--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -155,12 +155,17 @@
     .wd {color: #005A9C; background-color: #EE9999}
     .ed, .fpwd  {color: #005A9C; background-color: #FF7777}
     code {white-space: pre;}
-    
+    </style>
+
+  </head>
+  <body>
+    <style>
     html {
       background-image: none !important;
     }
     body {
       background: white top left fixed no-repeat !important;
+      background-size: 25px auto !important;
       background-image: url('https://www.openactive.io/assets/openactive-label-editorsdraft.png') !important;
     }
     body.toc-sidebar #toc {
@@ -182,11 +187,7 @@
     code {
         color: #C83500;
     }
-
     </style>
-
-  </head>
-  <body>
     <section id='abstract'>
 This specification introduces a data model to support the publication of data describing 
 opportunities for people to engage in physical activities ("opportunity data"). This model 


### PR DESCRIPTION
Note that when viewed on a small device, the branding label on the left of the page is of incorrect size.

The order of styling is important (between head/body) as it dictates how they play with respec's own injected style sheets.