### PR TITLE
2.0 editors draft

### DIFF
--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -495,16 +495,28 @@ may run as a standalone event on a particular date.
 
 Other events take place on a regular __schedule__. For example a weekly gym class may 
 run every Wednesday evening at 7pm. While a local walking club might meet on a Saturday 
-morning once a month.
-
-In order to simplify terminology we recommend the use of the term "Event" to 
-refer to both individual occurrences and regularly occurring events. 
+morning once a month. 
 
 It is useful to publish data about both individual Events and those with recurring schedules. 
 People looking for opportunities to be active will be interested in both specific questions 
 ("what can I do tomorrow") and more general information about scheduled activities.
 
-Regardless of whether an event takes place only once or happens on a regular schedule, there 
+For some scheduled events, participants may not have to commit to attending every 
+session. They can drop-in for individual classes, or build up a regular habit to 
+improve their fitness. For other events, like a course, there is might be an 
+expectation that a participant will attend every class.
+
+Some large scale events, such as a family fun day, might consist of a programme 
+of smaller scheduled events that take place over the course of a single or multiple 
+days. 
+
+In order to simplify terminology in this specification we use the term "Event" 
+to refer to all types of opportunities, including one-off and 
+regularly occurring events. However in the detailed data model we distinguish 
+between some types of events to allow data users to better present opportunities 
+to potential participants. 
+
+Regardless of what type of an event is being described, there 
 is a range of additional information that may help describe the event to potential participants. 
 This includes:
 
@@ -592,14 +604,14 @@ Places may have additional descriptive properties, for example:
 * an address and/or geographic coordinates
 * opening hours
 
-## Programmes
+## Programmes and Brands
 
 Events are often organised and run in a variety of different ways. This tailoring 
 might include adjusting the activity to a particular type of participant, demographic. 
 Or it could include running the event in a particular style, e.g. with a fixed routine 
 or sequence of activities.
 
-A __*Programme*__ describes a method of carrying out a Physical Activity. Some programmes are very loosely defined. 
+A __*Programme*__ describes a means of organising and running a Physical Activity. Some programmes are very loosely defined. 
 While others are more structured and may be run to a specific agenda or in a particular style.
 
 Programmes are often associated with branding or marketing that helps participants understand more about what they 
@@ -758,8 +770,10 @@ definitions in SKOS, Schema.org and the OpenActive Vocabulary ([[OpenActive-Voca
     <tr>
       <td>Event</td>
       <td>[`schema:Event`](https://schema.org/Event)</td>
-      <td>Schema.org provides a well defined model for Events already with properties that cover many 
-      of the core requirements for opportunity data</td>
+      <td>Schema.org provides a well defined model for Events with properties that cover many 
+      of the core requirements for opportunity data. This specification defines some 
+      additional types of Event and properties for describing them in the context of 
+      publishing opportunity data.</td>
     <tr>
     <tr>
       <td>Place</td>
@@ -783,9 +797,9 @@ definitions in SKOS, Schema.org and the OpenActive Vocabulary ([[OpenActive-Voca
       <td>An individual person</td>
     <tr>
     <tr>
-      <td>Programme</td>
-      <td>[`skos:Concept`](https://www.w3.org/2009/08/skos-reference/skos.html#Concept)</td>
-      <td></td>
+      <td>Brand</td>
+      <td>[`schema:Brand`](https://schema.org/Brand)</td>
+      <td>The brand used to describe a programme of activities.</td>
     <tr>    
     <tr>
       <td>Offer</td>
@@ -1189,7 +1203,7 @@ This basic description can be improved by providing information about its locati
 }
 </code></pre>
 
-### Relating Events to Physical Activities
+### Relating events to Physical Activities
 
 <p>
 The [`oa:activity`](https://www.openactive.io/ns/#activity) property allows an 
@@ -1220,355 +1234,6 @@ List, e.g. the OpenActive Activity List ([[OpenActive-Activity-List]]).
 <p>
 Applications could include additional information, e.g. alternate labels for convenience of consumers.
 </p>
-
-### Categorising events
-
-<p>
-The [`oa:category`](https://www.openactive.io/ns/#category) property can be 
-used to associate an Event with one or more tags that provide some extra 
-context about an event. This might include general information on the intensity 
-and suitability. While this property can be used to add any arbitrary tags to 
-an Event, a common use case is the need to tag an event as being suitable for 
-a specific type of audience, e.g. Beginners. Where this information is 
-available, the [`oa:level`](https://www.openactive.io/ns/#level) property 
-can be used in preference to [`oa:category`](https://www.openactive.io/ns/#category). 
-</p>
-<p>
-If an application does not distinguish between different types of tags 
-associated with an Event, then it <em class="rfc2119">SHOULD</em> use the 
-more general [`oa:category`](https://www.openactive.io/ns/#category) property.
-</p>
-
-<pre class="example" title="Tagging an Event"><code>
-{
-  "@context": "https://www.openactive.io/ns/oa.jsonld",
-  "type": "Event",
-  "url": "http://www.example.org/events/1",
-  "name": "Tai chi Class",
-  "description": "A tai chi class intended for beginners",
-  "startDate": "2017-03-22T20:00:00-05:00",
-  "duration": "PT60M",
-  "category": [{
-    "type: "Concept",
-    "prefLabel": "Suitable For All"
-    },
-    {
-    "type: "Concept",
-    "prefLabel": "Low Intensity"
-  }],
-  "level": [{
-    "type: "Concept",
-    "prefLabel": "Beginner"
-  }]
-}
-</code>
-</pre>
-
-<p>
-Where an application is using a controlled vocabulary it 
-<em class="rfc2119">SHOULD</em> publish that vocabulary as structured data.
-</p>
-
-<div class="note">
-In future, the OpenActive Community Group may decide to define and recommend 
-some controlled vocabularies for use in these properties. At present the 
-values of these properties are left deliberately open to encourage publication 
-of open data that may inform future standardisation.
-</div>
-
-### Describing Event Suitability
-
-<p>
-There are a variety of ways in which the suitability of an event for specific 
-audiences can be expressed. This includes specifying that 
-an event is:
-</p>
-
-* suited for a specific age range
-* suited for people with specific levels of experience ([`oa:level`](https://www.openactive.io/ns/#level))
-* restricted to a male, female or mixed audience
-
-#### Age Ranges
-
-<p>
-Age ranges are specified using the [`oa:ageRange`](https://www.openactive.io/ns/#ageRange) property. 
-The value is a [`schema:QuantitativeValue`](http://schema.org/QuantitativeValue) 
-which should have [minValue](http://schema.org/minValue) or 
-[maxValue](http://schema.org/maxValue) properties. These properties specify an 
-inclusive minimum and maximum age range for participants.
-</p>
-
-<p>
-Data publishers using the [`oa:ageRange`](https://www.openactive.io/ns/#ageRange) 
-property MUST ensure that it has:
-</p>
-
-* a `type` of [`schema:QuantitativeValue`](http://schema.org/QuantitativeValue)
-* at least one of the `minValue` or `maxValue`properties
-
-<p>
-Data consumers SHOULD assume that:
-</p>
-
-* if there is no `ageRange` property for an Event, then the event is suitable for adults only. E.g. as if the `minValue` has been specified as `18`
-* if an `ageRange` is provided without a `minValue` property, then there is no minimum age for the `Event`
-* if an `ageRange` is provided without a `maxValue` property, then there is no maximum age for the `Event`
-* if an `ageRange` is provided with a `minValue` of 0, and there is no `maxValue` property then the Event is suitable for all
-
-<p>
-The following example illustrates how to specify an Event that is suitable for people aged 60 or over.
-</p>
-
-<pre class="example" title="Age range example"><code>
-{
-  "@context": "https://www.openactive.io/ns/oa.jsonld",
-  "type": "Event",
-  "url": "http://www.example.org/events/1",
-  "name": "Tai chi Class",
-  "ageRange": {
-     "type": "QuantitativeValue",
-     "minValue": 60
-  }
-}
-</code>
-</pre>
-
-<p>
-The following example illustrates an Event that is suitable for all ages. 
-This is indicated by providing an `minValue` property with a value of zero and 
-no `maxValue` property.
-</p>
-
-<pre class="example" title="Age range - suitable for all example"><code>
-{
-  "@context": "https://www.openactive.io/ns/oa.jsonld",
-  "type": "Event",
-  "url": "http://www.example.org/events/1",
-  "name": "Exercise in the park",
-  "ageRange": {
-     "type": "QuantitativeValue",
-     "minValue": 0
-  }
-}
-</code>
-</pre>
-
-#### Gender Restriction
-
-<p>
-Attendance at some events is limited to certain audiences. For example a 
-female only gym class. The [`oa:genderRestriction`](https://www.openactive.io/ns/#genderRestriction) 
-property can be used to specify these restrictions.
-</p>
-
-<p>
-Data publishers using this property MUST use one of the following values:
-</p>
-
-* `https://www.openactive.io/ns#None` indicating that the event has no restrictions
-* `https://www.openactive.io/ns#Male` indicating that the event is restricted to the male gender
-* `https://www.openactive.io/ns#Female` indicating that the event is restricted to the female gender
-
-<p>
-If the `genderRestriction` property is not supplied for an Event, then data 
-consumers SHOULD NOT assume a default value, the value should be treated as 
-`null`. When searching or filtering for gender restricted Events, data 
-consumers SHOULD remove Events with a `null` value. 
-</p>
-
-<p>
-Invalid values for the `genderRestriction` property SHOULD be treated as `null`.
-</p>
-
-<pre class="example" title="Gender restriction example"><code>
-{
-  "@context": "https://www.openactive.io/ns/oa.jsonld",
-  "type": "Event",
-  "url": "http://www.example.org/events/1",
-  "name": "Gym class",
-  "genderRestriction": "http://www.openactive.io/ns#Female"
-}
-</code>
-</pre>
-
-<div class="note" title="Request for feedback">
-<p>The community group is aware of both the issues that arise from defining 
-standard terms for gender and the inclusivity issues that might arise from 
-restricting participation in events.</p>
-
-<p>We have standardised these terms to reflect the ways that events are currently 
-described. However there are many additional considerations that relate to how 
-gender is described and the ways that events might be advertised and run in order 
-for people to feel safe and included.</p>
-<p>
-We encourage the community to reflect on the approach outlined here and experiment 
-with alternative options. We have <a href="https://github.com/openactive/modelling-opportunity-data/issues/69#issuecomment-401336335"> outlined some of these options</a> and welcome feedback on how we can improve this area of the specification.
-</p>
-</div>
-
-
-### Adding programmes
-
-Events can be associated with a Programme using the 
-[`oa:programme`](https://www.openactive.io/ns/#programme) property. A programme
-is a [`schema:Brand`](http://schema.org/Brand) object.
-
-<pre class="example" title="Tagging an Event"><code>
-{
-  "@context": "https://www.openactive.io/ns/oa.jsonld",
-  "type": "Event",
-  "url": "http://www.example.org/events/1",
-  "name": "Rowing Class",
-  "description": "A rowing class for beginners",
-  "startDate": "2017-04-01T08:00:00Z",
-  "duration": "PT60M",
-  "programme": {
-    "type": "Brand",
-    "name": "Learn to Row",
-    "url": "https://www.britishrowing.org/go-rowing/learn-to-row/",
-    "description": "Getting started in rowing couldn’t be easier!"
-  }
-}
-</code>
-</pre>
-
-### Describing event schedules
-
-<div class="note" title="Schema.org support for recurring events">
-<p>
-This specification relies on some pending changes to Schema.org that will add recurrence rules to Events. The [proposal](https://github.com/schemaorg/schemaorg/pull/1693) has been accepted, but is not yet formally part of the model.
-</p>
-<p>We expect that this proposal will become part of Schema.org in due course. This process will be driven by implementation experience and feedback from the community. On that basis we have included the terms in specification. The following section is written on that basis. However both publishers and consumers should be aware that this is an area that may change in future versions.</p>
-</div>
-
-For Events that take place at a regular time it can be useful to publish information 
-about the schedule rather than the individual events. Providing a schedule, rather 
-than a list of individual events means publishing less data and clarifies that 
-each weekly or monthly occurence of an Event is part of a longer series.
-
-The [`schema:eventSchedule`](http://pending.schema.org/eventSchedule) property can 
-be used to describe a [`schema:Schedule`](http://pending.schema.org/Schedule) for 
-an Event.
-
-A Schedule define a repeating calendar entry with sufficient information that 
-future events can be generated from some basic rules.
-
-<table>
-  <thead>
-    <th>Property</th>
-    <th>Status</th>
-    <th>Format</th>
-    <th>Notes</th>
-  </thead>
-  <tbody>  
-    <tr>
-      <td>`@type`</td>
-      <td><em class="rfc2119">REQUIRED</em></td>
-      <td>String</td>
-      <td>`Schedule`</td>
-    </tr>  
-    <tr>
-      <td>[`schema:repeatFrequency`](https://pending.schema.org/repeatFrequency)</td>
-      <td><em class="rfc2119">REQUIRED</em></td>
-      <td>String</td>
-      <td>The frequency of the events, specified as an [[ISO8601]] duration, e.g. day, week, month</td>
-    </tr>  
-    <tr>
-      <td>[`schema:startDate`](https://schema.org/startDate)</td>
-      <td><em class="rfc2119">REQUIRED</em></td>
-      <td>String</td>
-      <td>Specifies the [`schema:Date`](http://schema.org/Date) from which the schedule 
-      is active</td>
-    </tr>  
-    <tr>
-      <td>[`schema:endDate`](https://schema.org/startDate)</td>
-      <td><em class="rfc2119">RECOMMENDED</em></td>
-      <td>String</td>
-      <td>Specifies the [`schema:Date`](http://schema.org/Date) at which the schedule 
-      ends.</td>
-    </tr>  
-    <tr>
-      <td>[`schema:startTime`](https://schema.org/startTime)</td>
-      <td><em class="rfc2119">REQUIRED</em></td>
-      <td>String</td>
-      <td>Specifies the [`schema:Time`](http://schema.org/Time) at which the 
-      Events will take place.</td>
-    </tr>  
-    <tr>
-      <td>[`schema:endTime`](https://schema.org/endTime)</td>
-      <td><em class="rfc2119">REQUIRED</em></td>
-      <td>String</td>
-      <td>Specifies the [`schema:Time`](http://schema.org/Time) at which the Events will end</td>
-    </tr> 
-    <tr>
-      <td>[`schema:duration`](https://schema.org/duration)</td>
-      <td><em class="rfc2119">RECOMMENDED</em></td>
-      <td>String</td>
-      <td>Specifies the duration of the Event as an [[ISO8601]] duration.  Durations 
-      MUST NOT be zero length. If duration is unknown it should be omitted.  A
-      duration MUST be provided if both a start and end date are available.</td>
-    </tr>     
-    <tr>
-      <td>[`schema:byDay`](https://pending.schema.org/byDay)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>Array of [`schema:DayOfWeek`](https://schema.org/DayOfWeek)</td>
-      <td>Lists the day(s) of the week during which the Events will take place.</td>
-    </tr>  
-    <tr>
-      <td>[`schema:byMonth`](https://pending.schema.org/byMonth)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>Array of Integers</td>
-      <td>Lists the month(s) of the year during which the Events will take place. January 
-      is the first month</td>
-    </tr>  
-    <tr>
-      <td>[`schema:byMonthDay`](https://pending.schema.org/byMonthDay)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>Array of Integers</td>
-      <td>Lists the day(s) of the month on which an Event will take place</td>
-    </tr>      
-    <tr>
-      <td>[`schema:repeatCount`](https://pending.schema.org/repeatCount)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>Number</td>
-      <td>Specifies that an Event will repeat the specified number of times</td>
-    </tr>
-    <tr>
-      <td>[`schema:exceptDate`](https://pending.schema.org/exceptDate)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>Array of [`Date`](http://schema.org/Date) or [`DateTime`](http://schema.org/DateTime)</td>
-      <td>Defines a list of [`Date`](http://schema.org/Date) or [`DateTime`](http://schema.org/DateTime) during which a scheduled Event will not take place. The property allows exceptions to a Schedule to be specified. If an exception is specified as a [`DateTime`](http://schema.org/DateTime) then only the event that would have started at that specific date and time should be excluded from the schedule. If an exception is specified as a [`Date`](http://schema.org/Date) then any event that is scheduled for that 24 hour period should be excluded from the schedule. This allows a whole day to be excluded from the schedule without having to itemise every scheduled event.</td>
-    </tr>
-  </tbody>   
-</table>
-
-While the [`schema:byDay`](https://pending.schema.org/byDay), [`schema:byMonth`](https://pending.schema.org/byMonth) 
-and [`schema:byMonthDay`](https://pending.schema.org/byMonthDay) properties are 
-optional, one of these properties MUST be provided.
-
-The following example illustrates basic usage of the [`schema:eventSchedule`](http://pending.schema.org/eventSchedule) property to associate an `Event` with a [`schema:Schedule`](http://pending.schema.org/Schedule). The data describes a Tai Chi class that occurs every Wednesday at 7pm
-
-<pre class="example" title="Adding an event schedule"><code>
-{
-  "@context": "https://www.openactive.io/ns/oa.jsonld",
-  "type": "Event",
-  "url": "http://www.example.org/events/1",
-  "name": "Tai chi Class",
-  "description": "A tai chi class intended for beginners",
-  "duration": "PT60M",
-  "eventSchedule": {
-     "type": "Schedule",
-     "startDate": "2017-01-01",
-     "endDate": "2017-12-31",
-     "repeatFrequency": "P1W",
-     "byDay": "http://schema.org/Wednesday",
-     "startTime": "19:00",
-     "endTime": "20:00",
-     "duration": "PT1H"
-  }  
-}
-</code>
-</pre>
 
 ### Describing event availability
 
@@ -1633,7 +1298,217 @@ The following example shows a Tai chi class that has been cancelled:
 </code>
 </pre>
 
-### Describing support for disabilities at events
+### Categorising events
+
+<p>
+The [`oa:category`](https://www.openactive.io/ns/#category) property can be 
+used to associate an Event with one or more tags that provide some extra 
+context about an event. This might include general information on the intensity 
+and suitability. While this property can be used to add any arbitrary tags to 
+an Event, a common use case is the need to tag an event as being suitable for 
+a specific type of audience, e.g. Beginners. Where this information is 
+available, the [`oa:level`](https://www.openactive.io/ns/#level) property 
+can be used in preference to [`oa:category`](https://www.openactive.io/ns/#category). 
+</p>
+<p>
+If an application does not distinguish between different types of tags 
+associated with an Event, then it <em class="rfc2119">SHOULD</em> use the 
+more general [`oa:category`](https://www.openactive.io/ns/#category) property.
+</p>
+
+<pre class="example" title="Tagging an Event"><code>
+{
+  "@context": "https://www.openactive.io/ns/oa.jsonld",
+  "type": "Event",
+  "url": "http://www.example.org/events/1",
+  "name": "Tai chi Class",
+  "description": "A tai chi class intended for beginners",
+  "startDate": "2017-03-22T20:00:00-05:00",
+  "duration": "PT60M",
+  "category": [{
+    "type: "Concept",
+    "prefLabel": "Suitable For All"
+    },
+    {
+    "type: "Concept",
+    "prefLabel": "Low Intensity"
+  }],
+  "level": [{
+    "type: "Concept",
+    "prefLabel": "Beginner"
+  }]
+}
+</code>
+</pre>
+
+<p>
+Where an application is using a controlled vocabulary it 
+<em class="rfc2119">SHOULD</em> publish that vocabulary as structured data.
+</p>
+
+<div class="note">
+In future, the OpenActive Community Group may decide to define and recommend 
+some controlled vocabularies for use in these properties. At present the 
+values of these properties are left deliberately open to encourage publication 
+of open data that may inform future standardisation.
+</div>
+
+### Adding programmes
+
+Events can be associated with a Programme using the 
+[`oa:programme`](https://www.openactive.io/ns/#programme) property. A programme
+is a [`schema:Brand`](http://schema.org/Brand) object.
+
+<pre class="example" title="Tagging an Event"><code>
+{
+  "@context": "https://www.openactive.io/ns/oa.jsonld",
+  "type": "Event",
+  "url": "http://www.example.org/events/1",
+  "name": "Rowing Class",
+  "description": "A rowing class for beginners",
+  "startDate": "2017-04-01T08:00:00Z",
+  "duration": "PT60M",
+  "programme": {
+    "type": "Brand",
+    "name": "Learn to Row",
+    "url": "https://www.britishrowing.org/go-rowing/learn-to-row/",
+    "description": "Getting started in rowing couldn’t be easier!"
+  }
+}
+</code>
+</pre>
+
+### Describing the audience suitability of events
+
+<p>
+There are a variety of ways in which the suitability of an event for specific 
+audiences can be expressed. This includes specifying that 
+an event is:
+</p>
+
+* suited for a specific age range
+* suited for people with specific levels of experience ([`oa:level`](https://www.openactive.io/ns/#level))
+* restricted to a male, female or mixed audience
+
+#### Age ranges
+
+<p>
+Age ranges are specified using the [`oa:ageRange`](https://www.openactive.io/ns/#ageRange) property. 
+The value is a [`schema:QuantitativeValue`](http://schema.org/QuantitativeValue) 
+which should have [minValue](http://schema.org/minValue) or 
+[maxValue](http://schema.org/maxValue) properties. These properties specify an 
+inclusive minimum and maximum age range for participants.
+</p>
+
+<p>
+Data publishers using the [`oa:ageRange`](https://www.openactive.io/ns/#ageRange) 
+property MUST ensure that it has:
+</p>
+
+* a `type` of [`schema:QuantitativeValue`](http://schema.org/QuantitativeValue)
+* at least one of the `minValue` or `maxValue`properties
+
+<p>
+Data consumers SHOULD assume that:
+</p>
+
+* if there is no `ageRange` property for an Event, then the event is suitable for adults only. E.g. as if the `minValue` has been specified as `18`
+* if an `ageRange` is provided without a `minValue` property, then there is no minimum age for the `Event`
+* if an `ageRange` is provided without a `maxValue` property, then there is no maximum age for the `Event`
+* if an `ageRange` is provided with a `minValue` of 0, and there is no `maxValue` property then the Event is suitable for all
+
+<p>
+The following example illustrates how to specify an Event that is suitable for people aged 60 or over.
+</p>
+
+<pre class="example" title="Age range example"><code>
+{
+  "@context": "https://www.openactive.io/ns/oa.jsonld",
+  "type": "Event",
+  "url": "http://www.example.org/events/1",
+  "name": "Tai chi Class",
+  "ageRange": {
+     "type": "QuantitativeValue",
+     "minValue": 60
+  }
+}
+</code>
+</pre>
+
+<p>
+The following example illustrates an Event that is suitable for all ages. 
+This is indicated by providing an `minValue` property with a value of zero and 
+no `maxValue` property.
+</p>
+
+<pre class="example" title="Age range - suitable for all example"><code>
+{
+  "@context": "https://www.openactive.io/ns/oa.jsonld",
+  "type": "Event",
+  "url": "http://www.example.org/events/1",
+  "name": "Exercise in the park",
+  "ageRange": {
+     "type": "QuantitativeValue",
+     "minValue": 0
+  }
+}
+</code>
+</pre>
+
+#### Gender restrictions
+
+<p>
+Attendance at some events is limited to certain audiences. For example a 
+female only gym class. The [`oa:genderRestriction`](https://www.openactive.io/ns/#genderRestriction) 
+property can be used to specify these restrictions.
+</p>
+
+<p>
+Data publishers using this property MUST use one of the following values:
+</p>
+
+* `https://www.openactive.io/ns#None` indicating that the event has no restrictions
+* `https://www.openactive.io/ns#Male` indicating that the event is restricted to the male gender
+* `https://www.openactive.io/ns#Female` indicating that the event is restricted to the female gender
+
+<p>
+If the `genderRestriction` property is not supplied for an Event, then data 
+consumers SHOULD NOT assume a default value, the value should be treated as 
+`null`. When searching or filtering for gender restricted Events, data 
+consumers SHOULD remove Events with a `null` value. 
+</p>
+
+<p>
+Invalid values for the `genderRestriction` property SHOULD be treated as `null`.
+</p>
+
+<pre class="example" title="Gender restriction example"><code>
+{
+  "@context": "https://www.openactive.io/ns/oa.jsonld",
+  "type": "Event",
+  "url": "http://www.example.org/events/1",
+  "name": "Gym class",
+  "genderRestriction": "http://www.openactive.io/ns#Female"
+}
+</code>
+</pre>
+
+<div class="note" title="Request for feedback">
+<p>The community group is aware of both the issues that arise from defining 
+standard terms for gender and the inclusivity issues that might arise from 
+restricting participation in events.</p>
+
+<p>We have standardised these terms to reflect the ways that events are currently 
+described. However there are many additional considerations that relate to how 
+gender is described and the ways that events might be advertised and run in order 
+for people to feel safe and included.</p>
+<p>
+We encourage the community to reflect on the approach outlined here and experiment 
+with alternative options. We have <a href="https://github.com/openactive/modelling-opportunity-data/issues/69#issuecomment-401336335"> outlined some of these options</a> and welcome feedback on how we can improve this area of the specification.
+</p>
+</div>
+
+#### Describing support for disabilities
 
 <p>
 This specification defines several ways to capture information from organisers 
@@ -1659,6 +1534,400 @@ Examples of using these are shown below:
   "duration": "PT60M",
   "accessibilitySupport": ["Hearing Impairment", "Visual Impairment"],
   "accessibilityInformation": "The location is fully accessible, please contact the organiser if you have questions"
+}
+</code>
+</pre>
+
+### Parent-child relationships between Events
+
+Events are often related to one another in parent-child relationships. For 
+example a whole day event (the parent) might consist of a programme of 
+shorter events such as individual races that take place at 
+different times of the day (the children).
+
+This type of relationship between events can be described using the 
+[`schema:subEvent`](https://schema.org/subEvent) and [`schema:superEvent`](https://schema.org/superEvent) 
+properties.
+
+<pre class="example" title="Parent-child Events"><code>
+{
+  "@context": "https://www.openactive.io/ns/oa.jsonld",
+  "type": "HeadlineEvent",
+  "url": "http://www.example.org/events/1",
+  "name": "Aquathlon Day",
+  "description": "A day of aquathlon races",
+  "startDate": "2018-09-01T09:00:00-05:00",
+  "endDate": "2018-09-01T17:00:00-05:00",  
+  "duration": "P1D",
+  "subEvent": [
+    {
+      "type": "Event",
+      "url": "http://www.example.org/events/2",
+      "name": "Aquathlon Sprint",
+      "startDate": "2018-09-01T10:00:00-05:00" 
+    },
+    {
+      "type": "Event",
+      "url": "http://www.example.org/events/2",
+      "name": "Aquathlon Long Course",
+      "startDate": "2018-09-01T14:00:00-05:00" 
+    }    
+  ]
+}
+</code>
+</pre>
+
+The `HeadlineEvent` type used in this example is described in the following 
+section.
+
+When not otherwise specified on the child event, a consumer MAY assume that 
+some properties that describe the parent (`schema:superEvent`) event, such as 
+its location, organizer or audience suitability, also applies to the child. 
+This is referred to as "__property inheritance__". 
+
+If a child Event provides a property with the same name as its parent 
+(e.g. `startDate`) then consumers MUST use the value provided for the child and 
+not the parent.
+
+However consumers MUST NOT assume that Offers provided for a parent event are 
+automatically inherited by child events. Some types of event (see below) do 
+allow for inheritance of Offers. This is covered further in the next section.
+
+Some properties are never inherited. These include `@type`, `@id`, `schema:url`, 
+`schema:identifier` and `schema:eventSchedule`.
+
+<div class="note" title="Grouping events">
+Events may also be related together in other ways, e.g. as a regular series like 
+the Olympic Games or the London Marathon. This specification does not yet document 
+how to describe series or other groups of Events. However we expect that 
+future versions may recommend use of the draft 
+Schema.org [`EventSeries`](https://pending.schema.org/EventSeries) type. Publishers 
+MAY wish to experiment with using this property in their data.
+</div>
+
+### Types of event
+
+[`schema:Event`](https://schema.org/Event) provides a useful default type for 
+describing Events.
+
+However in practice it can be useful to distinguish between some specific types 
+of Event. This gives data consumers more context that can help them index and 
+recommended Events to potential participants. Recognising additional types of 
+Event can also be useful in defining additional conformance and validation 
+rules that guide how data is published and used.
+
+This specification defines several sub-types of Event. These are described in 
+the following sections. Unless otherwise specified:
+
+* all of the properties defined for [`schema:Event`](https://schema.org/Event) 
+can applied to each sub-type
+* properties have the same status (e.g. REQUIRED) as for the generic type
+* the property inheritance rules defined in the previous section apply to each 
+sub-type
+
+Where publishers are unsure whether a sub-type applies they SHOULD use the 
+generic [`schema:Event`](https://schema.org/Event) type. Publishers MUST NOT use 
+any of these sub-types to describe other forms of Event.
+
+When data consumers encounter a new sub-type of Event, they SHOULD treat it as if 
+it were of the generic [`schema:Event`](https://schema.org/Event) type. New sub-types 
+might be defined in future versions of this specification or as custom types by 
+individual publishers.
+
+#### Regular sessions (`SessionSeries` and `ScheduledSession`)
+
+Many organisers run regularly scheduled Events, e.g. a weekly exercise class or 
+a monthly ride of a cycle club. 
+
+These can be thought of as two distinct types of Event:
+
+* [`oa:SessionSeries`](https://www.openactive.io/ns/#SessionSeries) - the overall series of events, e.g. Wednesday Yoga
+* [`oa:ScheduledSession`](https://www.openactive.io/ns/#ScheduledSession) - the individual sessions, e.g. Wednesday Yoga 
+on 5th September 2018
+
+The following example illustrates how these types are used.
+
+<pre class="example" title="Scheduled Series"><code>
+{
+  "@context": "https://www.openactive.io/ns/oa.jsonld",
+  "type": "ScheduledSeries",
+  "url": "http://www.example.org/events/1",
+  "name": "Wednesday Yoga",
+  "description": "A day of aquathlon races",
+  "startDate": "2018-01-01",
+  "endDate": "2018-12-31"
+  "subEvent": [
+    {
+      "type": "ScheduledSession",
+      "url": "http://www.example.org/events/2",
+      "startDate": "2018-09-05T18:00:00-05:00",
+      "endDate": "2018-09-05T19:00:00-05:00",
+      "duration": "PT1H"       
+    },
+    ...    
+  ]
+}
+</code>
+</pre>
+
+Publishers SHOULD use the [`oa:SessionSeries`](https://www.openactive.io/ns/#SessionSeries) type for describing Events that 
+occur on a regular schedule. The child events of 
+a [`oa:SessionSeries`](https://www.openactive.io/ns/#SessionSeries)provided in a `subEvent` property MUST all be 
+of the [`oa:ScheduledSession`](https://www.openactive.io/ns/#ScheduledSession) type.
+
+In addition to the normal rules around property inheritance, data consumers 
+MAY also assume that Offers provided for a [`oa:SessionSeries`](https://www.openactive.io/ns/#SessionSeries) also apply to 
+their child events, of type [`oa:ScheduledSession`](https://www.openactive.io/ns/#ScheduledSession). 
+
+This is in the only time that Offers may be inherited between types. This is 
+permitted here as the parent Event exists to describe a series of sessions. The 
+individual sessions MAY have additional properties and consumers MUST use these 
+where provided.
+
+#### Headline events (`HeadlineEvent`)
+
+The ability to describe parent-child relationships between Events provides a 
+useful way to publish an event programme for a whole day or multi-day event, 
+such as a mass participation event, family fun day, etc.
+
+To help distinguish programmed events from the "headline" event itself, this 
+specification defines the [`oa:HeadlineEvent`](https://www.openactive.io/ns/#HeadlineEvent)
+type.
+
+<pre class="example" title="Headline Events"><code>
+{
+  "@context": "https://www.openactive.io/ns/oa.jsonld",
+  "type": "HeadlineEvent",
+  "url": "http://www.example.org/events/1",
+  "name": "Aquathlon Day",
+  "description": "A day of aquathlon races",
+  "startDate": "2018-09-01T09:00:00-05:00",
+  "endDate": "2018-09-01T17:00:00-05:00",  
+  "duration": "P1D",
+  "subEvent": [
+    {
+      "type": "Event",
+      "url": "http://www.example.org/events/2",
+      "name": "Aquathlon Sprint",
+      "startDate": "2018-09-01T10:00:00-05:00" 
+    },
+    {
+      "type": "Event",
+      "url": "http://www.example.org/events/2",
+      "name": "Aquathlon Long Course",
+      "startDate": "2018-09-01T14:00:00-05:00" 
+    }    
+  ]
+}
+</code>
+</pre>
+
+The [`oa:HeadlineEvent`](https://www.openactive.io/ns/#HeadlineEvent) is mainly 
+provided as a means for data consumers to treat these types of events differently 
+from [`oa:SessionSeries`](https://www.openactive.io/ns/#HeadlineEvent). 
+
+For example a web application might display a 
+[`oa:HeadlineEvent`](https://www.openactive.io/ns/#HeadlineEvent) with a custom page 
+that includes a summary of its programme of activities.
+
+A [`oa:HeadlineEvent`](https://www.openactive.io/ns/#HeadlineEvent) is an event in 
+its own right, and MUST NOT have an `schema:eventSchedule` property. Publishers 
+MUST provide a start date and optionally end date and duration for the event.
+
+As with the generic type, any Offers provided for a 
+[`oa:HeadlineEvent`](https://www.openactive.io/ns/#HeadlineEvent) apply to that 
+Event, they are not inherited by individual child events. However a publisher 
+MAY provide Offers for individual events in the programme if they are individually 
+ticketed.
+
+#### Courses (`CourseInstance`)
+
+Schema.org defines a [`Course`](https://pending.schema.org/Course) as an education 
+course that is run at different times and places. The course might consist of one or 
+more individual classes.
+
+These instances of a course are described using the 
+[`schema:CourseInstance`](https://pending.schema.org/CourseInstance) type.
+
+Publishers SHOULD use the [`schema:CourseInstance`](https://pending.schema.org/CourseInstance) 
+type when describing courses of any duration.
+
+<pre class="example" title="Course Instance"><code>
+{
+  "@context": "https://www.openactive.io/ns/oa.jsonld",
+  "type": "CourseInstance",
+  "url": "http://www.example.org/events/1",
+  "name": "Sailing Course",
+  "description": "A ten week sailing course",
+  "startDate": "2018-08-30",
+  "endDate": "2018-11-08"
+  "subEvent": [
+    {
+      "type": "Event",
+      "url": "http://www.example.org/events/2",
+      "startDate": "2018-08-30T09:00:00-05:00",
+      "endDate": "2018-08-30T10:00:00-05:00",
+      "duration": "PT1H"       
+    },
+    ...    
+  ]
+}
+</code>
+</pre>
+
+A [`schema:CourseInstance`](https://pending.schema.org/CourseInstance) MUST have 
+either a `subEvent` property AND/or an `eventSchedule` property that provides 
+information about the individual classes.
+
+Child events of a [`schema:CourseInstance`](https://pending.schema.org/CourseInstance) 
+SHOULD be of the generic `schema:Event` type.
+
+A participant will typically pay to attend a whole course. So, as with the 
+generic type, any Offers provided for a [[`schema:CourseInstance`](https://pending.schema.org/CourseInstance) 
+apply to the whole course any not the individual classes. However a publisher 
+MAY provide Offers for individual events in the programme if they are individually 
+ticketed.
+
+<div class="note" title="Status of CourseInstance">
+[`schema:CourseInstance`](https://pending.schema.org/CourseInstance) is currently 
+a draft Schema.org property. As a result, both publishers and consumers should be aware 
+that its definition may need to change in future versions of this specification.
+</div>
+
+### Describing event schedules
+
+<div class="note" title="Schema.org support for recurring events">
+<p>
+This specification relies on some pending changes to Schema.org that will add recurrence rules to Events. The [proposal](https://github.com/schemaorg/schemaorg/pull/1693) has been accepted, but is not yet formally part of the model.
+</p>
+<p>We expect that this proposal will become part of Schema.org in due course. This process will be driven by implementation experience and feedback from the community. On that basis we have included the terms in specification. The following section is written on that basis. However both publishers and consumers should be aware that this is an area that may change in future versions.</p>
+</div>
+
+For Events that take place at a regular time it can be useful to publish information 
+about the schedule rather than the individual events. Providing a schedule, rather 
+than a list of individual events means publishing less data and clarifies that 
+each weekly or monthly occurence of an Event is part of a longer series.
+
+The [`schema:eventSchedule`](http://pending.schema.org/eventSchedule) property can 
+be used to describe a [`schema:Schedule`](http://pending.schema.org/Schedule) for 
+an Event.
+
+A Schedule define a repeating calendar entry with sufficient information that 
+future events can be generated from some basic rules.
+
+<table>
+  <thead>
+    <th>Property</th>
+    <th>Status</th>
+    <th>Format</th>
+    <th>Notes</th>
+  </thead>
+  <tbody>  
+    <tr>
+      <td>`@type`</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>`Schedule`</td>
+    </tr>  
+    <tr>
+      <td>[`schema:repeatFrequency`](https://pending.schema.org/repeatFrequency)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>The frequency of the events, specified as an [[ISO8601]] duration, e.g. day, week, month</td>
+    </tr>  
+    <tr>
+      <td>[`schema:startDate`](https://schema.org/startDate)</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
+      <td>Specifies the [`schema:Date`](http://schema.org/Date) from which the schedule 
+      is active</td>
+    </tr>  
+    <tr>
+      <td>[`schema:endDate`](https://schema.org/startDate)</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
+      <td>Specifies the [`schema:Date`](http://schema.org/Date) at which the schedule 
+      ends.</td>
+    </tr>  
+    <tr>
+      <td>[`schema:startTime`](https://schema.org/startTime)</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
+      <td>Specifies the [`schema:Time`](http://schema.org/Time) at which the 
+      Events will take place.</td>
+    </tr>  
+    <tr>
+      <td>[`schema:endTime`](https://schema.org/endTime)</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
+      <td>Specifies the [`schema:Time`](http://schema.org/Time) at which the Events will end</td>
+    </tr> 
+    <tr>
+      <td>[`schema:duration`](https://schema.org/duration)</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
+      <td>Specifies the duration of the Event as an [[ISO8601]] duration.  Durations 
+      MUST NOT be zero length. If duration is unknown it should be omitted.  A
+      duration MUST be provided if both a start and end date are available.</td>
+    </tr>     
+    <tr>
+      <td>[`schema:byDay`](https://pending.schema.org/byDay)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of [`schema:DayOfWeek`](https://schema.org/DayOfWeek)</td>
+      <td>Lists the day(s) of the week during which the Events will take place.</td>
+    </tr>  
+    <tr>
+      <td>[`schema:byMonth`](https://pending.schema.org/byMonth)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of Integers</td>
+      <td>Lists the month(s) of the year during which the Events will take place. January 
+      is the first month</td>
+    </tr>  
+    <tr>
+      <td>[`schema:byMonthDay`](https://pending.schema.org/byMonthDay)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of Integers</td>
+      <td>Lists the day(s) of the month on which an Event will take place</td>
+    </tr>      
+    <tr>
+      <td>[`schema:repeatCount`](https://pending.schema.org/repeatCount)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Number</td>
+      <td>Specifies that an Event will repeat the specified number of times</td>
+    </tr>
+    <tr>
+      <td>[`schema:exceptDate`](https://pending.schema.org/exceptDate)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of [`Date`](http://schema.org/Date) or [`DateTime`](http://schema.org/DateTime)</td>
+      <td>Defines a list of [`Date`](http://schema.org/Date) or [`DateTime`](http://schema.org/DateTime) during which a scheduled Event will not take place. The property allows exceptions to a Schedule to be specified. If an exception is specified as a [`DateTime`](http://schema.org/DateTime) then only the event that would have started at that specific date and time should be excluded from the schedule. If an exception is specified as a [`Date`](http://schema.org/Date) then any event that is scheduled for that 24 hour period should be excluded from the schedule. This allows a whole day to be excluded from the schedule without having to itemise every scheduled event.</td>
+    </tr>
+  </tbody>   
+</table>
+
+While the [`schema:byDay`](https://pending.schema.org/byDay), [`schema:byMonth`](https://pending.schema.org/byMonth) 
+and [`schema:byMonthDay`](https://pending.schema.org/byMonthDay) properties are 
+optional, one of these properties SHOULD be provided.
+
+The following example illustrates basic usage of the [`schema:eventSchedule`](http://pending.schema.org/eventSchedule) property to associate an `Event` with a [`schema:Schedule`](http://pending.schema.org/Schedule). The data describes a Tai Chi class that occurs every Wednesday at 7pm
+
+<pre class="example" title="Adding an event schedule"><code>
+{
+  "@context": "https://www.openactive.io/ns/oa.jsonld",
+  "type": "Event",
+  "url": "http://www.example.org/events/1",
+  "name": "Tai chi Class",
+  "description": "A tai chi class intended for beginners",
+  "duration": "PT60M",
+  "eventSchedule": {
+     "type": "Schedule",
+     "startDate": "2017-01-01",
+     "endDate": "2017-12-31",
+     "repeatFrequency": "P1W",
+     "byDay": "http://schema.org/Wednesday",
+     "startTime": "19:00",
+     "endTime": "20:00",
+     "duration": "PT1H"
+  }  
 }
 </code>
 </pre>

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -961,7 +961,8 @@ existing Schema.org properties and/or properties defined in the OpenActive Vocab
       <td>[`schema:duration`](https://schema.org/duration)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
       <td>String</td>
-      <td>The duration of the event given in [[ISO8601]] format.</td>
+      <td>The duration of the event given in [[ISO8601]] format. Durations 
+      MUST NOT be zero length. If duration is unknown it should be omitted.</td>
     </tr>
     <tr>
       <td>[`schema:location`](https://schema.org/location)</td>
@@ -1101,6 +1102,16 @@ existing Schema.org properties and/or properties defined in the OpenActive Vocab
       <td>Indicates that an Event is free to attend. Publishers supporting booking <em class="rfc2119">SHOULD</em> also 
       define a zero priced [`schema:Offer`](https://schema.org/Offer)</td>
     </tr>    
+    <tr>
+      <td>[`oa:isAccessibleWithoutBooking`](https://www.openactive.io/ns/#isAccessibleWithoutBooking)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Boolean</td>
+      <td>If this is `true` then a participant can turn up and participate on the 
+      day. There may also be opportunities for them to book in advance. If the 
+      property is `false` then a user MUST book in advance. In this case there 
+      MUST be at least one bookable Offer for the Event.</td>
+    </tr>    
+
     <tr>
       <td>[`schema:offers`](https://schema.org/offers)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
@@ -1465,7 +1476,8 @@ future events can be generated from some basic rules.
       <td>[`schema:duration`](https://schema.org/duration)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
       <td>String</td>
-      <td>Specifies the duration of the Event as an [[ISO8601]] duration.</td>
+      <td>Specifies the duration of the Event as an [[ISO8601]] duration.  Durations 
+      MUST NOT be zero length. If duration is unknown it should be omitted.</td>
     </tr>     
     <tr>
       <td>[`schema:byDay`](https://pending.schema.org/byDay)</td>
@@ -1884,9 +1896,9 @@ Schema.org provides the [`schema:amenityFeature`](http://schema.org/amenityFeatu
 
 To improve consistency in how amenities are published, this specification defines some common types of amenities:
 
-* [`ChangingRooms`](https://www.openactive.io/ns#ChangingRooms)
+* [`ChangingFacilities`](https://www.openactive.io/ns#ChangingFacilities)
 * [`Showers`](https://www.openactive.io/ns#Showers)
-* [`PublicToilets`](https://www.openactive.io/ns#PublicToilets)
+* [`Toilets`](https://www.openactive.io/ns#Toilets)
 * [`Lockers`](https://www.openactive.io/ns#Lockers)
 * [`Towels`](https://www.openactive.io/ns#Towels)
 * [`Creche`](https://www.openactive.io/ns#Creche)
@@ -2391,7 +2403,8 @@ for hire.
       <td>[`schema:duration`](https://schema.org/duration)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
       <td>String</td>
-      <td>The duration of the event given in [[ISO8601]] format.</td>
+      <td>The duration of the event given in [[ISO8601]] format.  Durations 
+      MUST NOT be zero length.</td>
     </tr>
     <tr>
       <td>[`schema:offers`](https://schema.org/offers)</td>
@@ -2519,11 +2532,18 @@ allow a participant to use that facility for a specified time and duration.
       <td>Specifies the hours during which this product is available. The value of this property is a schema:OpeningHoursSpecification.</td>
     </tr>
     <tr>
-      <td>[`oa:individualFacilityUses`](https://www.openactive.io/"htns/#individualFacilityUses)</td>
+      <td>[`oa:individualFacilityUse`](https://www.openactive.io/ns/#individualFacilityUse)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
       <td>Array of [`oa:IndividualFacilityUse`](https://www.openactive.io/"htns/#IndividualFacilityUse)</td>
       <td>Links a <code>oa:FacilityUse</code> product, describing a general opportunity to, e.g. book and play tennis at a leisure centre with an array of <code>oa:IndividualFacilityUse</code> products that provide a more detailed description about an opportunity to book, e.g. individual tennis courts. This allows a platform to publish both a general product and time-table as well as more detailed 
       products for individual facilities.</td>
+    </tr>
+    <tr>
+      <td>[`oa:groupFacilityUse`](https://www.openactive.io/ns/#groupFacilityUse)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>[`oa:FacilityUse`](https://www.openactive.io/ns/#FacilityUse)</td>
+      <td>Inverse of the [`oa:individualFacilityUse`](https://www.openactive.io/ns/#individualFacilityUse) property. Related an 
+      <code>oa:IndividualFacilityUse</code> (e.g. an opportunity to play tennis on a specific court) to a <code>oa:FacilityUse</code> (e.g. an opportunity to play tennis at a specific location).</td>
     </tr>
 
   </tbody>

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -872,64 +872,81 @@ within the sector to evolve as required.
 
 ## Describing Events (<code>schema:Event</code>)
 
+<p>
 The Schema.org [`schema:Event`](https://schema.org/Event) type corresponds to the definition of 
 Event given earlier in this specification. The properties and relationships associated with the 
 [`schema:Event`](https://schema.org/Event) type can all be used to describe events.
-
+</p>
+<p>
 The following table illustrates how the essential aspects of describing an event map to 
 existing Schema.org properties and/or properties defined in the OpenActive Vocabulary.
-
+</p>
 <table>
   <thead>
     <th>Property</th>
     <th>Status</th>
+    <th>Type</th>
     <th>Notes</th>
   </thead>
   <tbody>
     <tr>
-      <td>`@id`</td>
+      <td>`@type`</td>
       <td><em class="rfc2119">REQUIRED</em></td>
-      <td>A URI providing a unique identifier for the resource</td>
+      <td>String</td>
+      <td>Identifies the object as being an Event</td>
+    </tr>
+    <tr>
+      <td>`@id`</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>URI</td>
+      <td>A URI providing a unique, stable identifier for the resource</td>
     </tr>
     <tr>
       <td>[`schema:url`](https://schema.org/url)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
-      <td>A URL to a web page (or section of a page) that describes the event</td>
+      <td>URI</td>
+      <td>Link to a web page (or section of a page) that describes the event</td>
     </tr>
     <tr>
       <td>[`schema:identifier`](http://schema.org/identifier)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Number or String</td>
       <td>A local identifier for the resource</td>
     </tr>
     <tr>
       <td>[`schema:name`](https://schema.org/name)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
       <td>The name of the event</td>
     </tr>
     <tr>
       <td>[`schema:description`](https://schema.org/description)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
       <td>A free text description of the event</td>
     </tr>
     <tr>
       <td>[`schema:image`](https://schema.org/image)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>An image or photo that depicts the event, e.g. a photo taken at a previous event</td>
+      <td>Array of [`schema:ImageObject`](https://schema.org/ImageObject)</td>
+      <td>One or more images or photos that depicts the event, e.g. a photo taken at a previous event</td>
     </tr>
     <tr>
       <td>[`schema:startDate`](https://schema.org/startDate)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
       <td>
       <p>The start date and time of the event. Can be specified as a [`schema:Date`](https://schema.org/Date) or
       [`schema:DateTime`](https://schema.org/DateTime).
       </p>
       <p>While this property is marked as <em class="rfc2119">OPTIONAL</em>, a data publisher <em class="rfc2119">MUST</em> 
-      provide either a [`schema:startDate`](https://schema.org/startDate) or specify a [`oa:schedule`]() for an event. 
+      provide either a [`schema:startDate`](https://schema.org/startDate) or specify a [`schema:schedule`](https://pending.schema.org/Schedule) for an event. 
       </td>
     </tr>
     <tr>
       <td>[`schema:endDate`](https://schema.org/endDate)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
       <td>
       <p>
       The end date and time of the event. Can be specified as a [`schema:Date`](https://schema.org/Date) or
@@ -943,136 +960,167 @@ existing Schema.org properties and/or properties defined in the OpenActive Vocab
     <tr>
       <td>[`schema:duration`](https://schema.org/duration)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
       <td>The duration of the event given in [[ISO8601]] format.</td>
     </tr>
     <tr>
       <td>[`schema:location`](https://schema.org/location)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>[`schema:Place`](https://schema.org/Place)</td>
       <td>The location at which the event will take place. Or, in the case of events that may span multiple locations, the initial meeting or starting point.
-      <p>
-      It is recommended that locations <em class="rfc2119">SHOULD</em> be specified as a [`schema:Place`](https://schema.org/Place) complete with a 
-      fully described geographic location and/or address.
-      </p> 
-      <p>If only an address is available then this <em class="rfc2119">SHOULD</em> be described as a 
-      [`schema:PostalAddress`](https://schema.org/PostalAddress).
-      </p>
-      <p>Applications <em class="rfc2119">MAY</em> use [`schema:Text`](https://schema.org/Text) to provide 
-      a more general description of a location ("In Victoria Park, near the lake"), but this is not recommended: consuming applications 
-      will be unable to help users discover opportunities based on their location.
-      </p>
       </td>
     </tr>
     <tr>
       <td>[`schema:organizer`](https://schema.org/organizer)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
-      <td>The person or organization ultimately responsible for an event. An organizer might be an [`schema:Organization`](https://schema.org/Organization) or 
+      <td>Array of [`schema:Person`](https://schema.org/Person) or [`schema:Organization`](https://schema.org/Organization)</td>
+      <td>One or more people or organizations responsible for running an event. An organizer might be an [`schema:Organization`](https://schema.org/Organization) or 
       a [`schema:Person`]((https://schema.org/Person).</td>
     </tr>
     <tr>
       <td>[`schema:contributor`](https://schema.org/contributor)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
-      <td>A [`schema:Person`]((https://schema.org/Person), e.g. a coach, staff member or volunteer who will be helping to run the event.</td>
+      <td>Array of [`schema:Person`](https://schema.org/Person)</td>
+      <td>One or more people, e.g. a coach, staff member or volunteer who will be helping to run the event.</td>
     </tr>
     <tr>
       <td>[`schema:maximumAttendeeCapacity`](http://schema.org/maximumAttendeeCapacity)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Integer</td>
       <td>The maximum capacity of the event</td>
     </tr>
     <tr>
       <td>[`schema:remainingAttendeeCapacity`](http://schema.org/remainingAttendeeCapacity)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Integer</td>
       <td>The number of places that are still available for the event</td>
     </tr>
     <tr>
       <td>[`schema:eventStatus`](http://schema.org/eventStatus)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>[`schema:EventStatusType`](http://schema.org/EventStatusType)</td>
       <td>The status of an event. Can be used to indicate rescheduled or cancelled events</td>
     </tr>
     <tr>
       <td>[`schema:subEvent`](http://schema.org/subEvent)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>Relates a parent event to a child event. Properties describing the parent event can be assumed to apply to the child, unless otherwise specified. 
-      A child event might be a specific instance of an Event within a schedule</td>
+      <td>Array of [`schema:Event`](http://schema.org/Event)</td>
+      <td>Relates a parent event to one or more child events. Properties describing the parent event can be assumed to apply to the child, unless otherwise specified. A child event might be a specific instance of an Event within a schedule</td>
     </tr>
     <tr>
       <td>[`schema:superEvent`](http://schema.org/superEvent)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>Relates a child event to a parent event. Properties describing the parent event can be assumed to apply to the child, unless otherwise specified. 
-      A parent event might specify a recurring schedule, of which the child event is one specific instance</td>
+      <td>[`schema:Event`](http://schema.org/Event)</td>
+      <td>Relates a child event to a parent event. Properties describing the parent event can be assumed to apply to the child, unless otherwise specified. A parent event might specify a recurring schedule, of which the child event is one specific instance</td>
     </tr>
     <tr>
       <td>`schema:schedule`</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>[`schema:Schedule`](https://pending.schema.org/Schedule)</td>
       <td>A schedule defines a repeating time period used to describe a regularly occurring Event.</td>
     </tr>
     <tr>
       <td>[`oa:activity`](https://www.openactive.io/ns/#activity)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
-      <td>Specifies the physical activity or activities that will take place during an event</td>
+      <td>Array of [`skos:Concept`](https://www.w3.org/2009/08/skos-reference/skos.html#Concept)</td>
+      <td>Specifies one or more physical activities that will take place during an event</td>
     </tr>
     <tr>
       <td>[`oa:category`](https://www.openactive.io/ns/#category)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>Array of [`skos:Concept`](https://www.w3.org/2009/08/skos-reference/skos.html#Concept)</td>
       <td>Provides a set of tags that help categorise and describe an event, e.g. its intensity, purpose, etc.</td>
     </tr>
     <tr>
       <td>[`oa:ageRange`](https://www.openactive.io/ns/#ageRange)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>Indicates that an event is suitable for a specific age range. Specified as a [QuantifiedValue](http://schema.org/QuantitativeValue) with 
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>[`schema:QuantitativeValue`](https://schema.org/QuantitativeValue)</td>
+      <td>Indicates that an event is suitable for a specific age range. Specified as a [QuantitativeValue](http://schema.org/QuantitativeValue) with 
       [minValue](http://schema.org/minValue) and [maxValue](http://schema.org/maxValue) properties</td>
     </tr>
     <tr>
       <td>[`oa:genderRestriction`](https://www.openactive.io/ns/#genderRestriction)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>[`oa:GenderRestrictionType`](https://www.openactive.io/ns/#GenderRestrictionType)</td>
       <td>Indicates that an event is restricted to Male, Female or a Mixed audience. Values should be one of the three URIs defined by this specification (see below). If a gender restriction isn't specified then applications 
       <em class="rfc2119">SHOULD</em> assume that an event is suitable for a mixed audience</td>
     </tr>
     <tr>
       <td>[`oa:programme`](https://www.openactive.io/ns/#programme)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>[`schema:Brand`](https://schema.org/Brand)</td>
       <td>Indicates that an event will be organised according to a specific Programme</td>
     </tr>
     <tr>
       <td>[`oa:attendeeInstructions`](https://www.openactive.io/ns/#attendeeInstructions)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>String</td>
       <td>Provides additional notes and instructions for event attendees. E.g. more information on how to find the event, what to bring, etc.</td>
     </tr>
     <tr>
       <td>[`oa:leader`](https://www.openactive.io/ns/#leader)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of [`schema:Person`](https://schema.org/Person)</td>
       <td>Refers to a person (`schema:Person`) who will be leading an event. E.g. a coach. This is a more specific role than an organiser or a contributor</td>
     </tr>    
     <tr>
       <td>[`oa:accessibilitySupport`](https://www.openactive.io/ns/#accessibilitySupport)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of String or [`skos:Concept`](https://www.w3.org/2009/08/skos-reference/skos.html#Concept)</td>
       <td>Used to specify the types of disabilities or impairments that are supported at an event</td>
     </tr>    
     <tr>
       <td>[`oa:accessibilityInformation`](https://www.openactive.io/ns/#accessibilitySupport)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>String</td>
       <td>Provide additional, specific documentation for participants about how disabilities are, or can be supported at the Event.</td>
     </tr>    
     <tr>
       <td>[`oa:isCoached`](https://www.openactive.io/ns/#isCoached)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>A boolean property that indicates whether an Event will be coached. This flag allows an Event to be marked as being coached without having to specify a named individual as a coach. This addresses both privacy concerns and also scenarios where the actual coach may only be decided on the day.</td>
+      <td>Boolean</td>
+      <td>A boolean property that indicates whether an Event will be coached. This flag allows an Event to be marked as being coached without having to specify a named individual as a coach. This addresses both privacy concerns and also scenarios where the actual coach may only be decided on the day. If this property is not specified then consumers <em class="rfc2119">SHOULD</em> assume a value 
+      of undefined</td>
     </tr>    
     <tr>
       <td>[`oa:level`](https://www.openactive.io/ns/#level)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>Array of String or [`skos:Concept`](https://www.w3.org/2009/08/skos-reference/skos.html#Concept)</td>
       <td>A general purpose property for specifying the suitability of an event for different participant “levels”. E.g. beginner/intermediate/advanced. Or in the case of martial arts, specific belt requirements. Values <em class="rfc2119">SHOULD</em> ideally be drawn from a controlled vocabulary.</td>
     </tr>    
     <tr>
       <td>[`oa:meetingPoint`](https://www.openactive.io/ns/#meetingPoint)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>String</td>
       <td>Instructions for the attendees of an Event about where they should meet the organizer or leader at the start of the event. Some larger locations may have several possible meeting points, so this property provides additional more specific directions.</td>
     </tr>    
-
+    <tr>
+      <td>[`schema:isAccessibleForFree`](https://schema.org/isAccessibleForFree)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Boolean</td>
+      <td>Indicates that an Event is free to attend. Publishers supporting booking <em class="rfc2119">SHOULD</em> also 
+      define a zero priced [`schema:Offer`](https://schema.org/Offer)</td>
+    </tr>    
+    <tr>
+      <td>[`schema:offers`](https://schema.org/offers)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of [`schema:Offer`](https://schema.org/Offer)</td>
+      <td>Provides one or more offers to book and participate in an Event</td>
+    </tr>    
+    <tr>
+      <td>[`schema:potentialAction`](https://schema.org/potentialAction)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of [`schema:Action`](https://schema.org/Action)</td>
+      <td>Provides one or more actions that can be carried out on this Event, 
+      e.g. through interacting with an API or other service.  The 
+      [[Open-Booking-API]] defines a `ReserveAction`.</td>
+    </tr>    
 
   </tbody>
 </table>
-
+<p>
 The following example shows a simple event description, including its start time and duration:
+</p>
 
 <pre class="example" title="Simple event description"><code>
 {
@@ -1100,11 +1148,11 @@ This basic description can be improved by providing information about its locati
   "attendeeInstructions": "Please wear trainers and comfortable clothing",
   "startDate": "2017-03-22T20:00:00-05:00",
   "duration": "PT60M",
-  "organizer": {
+  "organizer": [{
     "type": "Organization",
     "url": "http://example.org/orgs/bristol-tai-chi",
     "name": "Bristol Tai Chi"  
-  },
+  }],
   "location": {
     "type": "Place",
     "name": "ExampleCo Gym",
@@ -1120,42 +1168,12 @@ This basic description can be improved by providing information about its locati
 
 ### Relating Events to Physical Activities
 
-The [`oa:activity`](https://www.openactive.io/ns/#activity) property allows an event to be associated with one or more Physical Activities. Its simplest usage is as follows:
-
-<pre class="example" title="Specifying activities"><code>
-{
-  "@context": "https://www.openactive.io/ns/oa.jsonld",
-  "type": "Event",
-  "url": "http://www.example.org/events/1",
-  "name": "Tai chi Class",
-  "description": "A tai chi class intended for beginners",
-  "startDate": "2017-03-22T20:00:00-05:00",
-  "duration": "PT60M",
-  "activity": "Tai chi"
-}
-</code>
-</pre>
-
-This specifies that the event will involve Tai Chi. Multiple activities can be specified by using repeated values:
-
-<pre class="example" title="Specifying multiple activities"><code>
-{
-  "@context": "https://www.openactive.io/ns/oa.jsonld",
-  "type": "Event",
-  "url": "http://www.example.org/events/1",
-  "name": "Tai chi Class",
-  "description": "A tai chi class intended for beginners",
-  "startDate": "2017-03-22T20:00:00-05:00",
-  "duration": "PT60M",
-  "activity": ["Tai chi", "Martial Arts", "Combat"]
-}
-</code>
-</pre>
-
-The Physical Activities used to describe an event may be drawn from a standard Activity List, e.g. the OpenActive Activity List ([[OpenActive-Activity-List]]). 
-
-In this case it is useful to make this clear in the opportunity data. In the following example the Physical Activity associated with the Event 
-is shown as a structured value. This allows more information to be provided, including its identifier, its label and a reference to the identifier of the Activity List from which it has been drawn:
+<p>
+The [`oa:activity`](https://www.openactive.io/ns/#activity) property allows an 
+event to be associated with one or more Physical Activities. The Physical 
+Activities used to describe an event may be drawn from a standard Activity 
+List, e.g. the OpenActive Activity List ([[OpenActive-Activity-List]]). 
+</p>
 
 <pre class="example" title="Using activities from an Activity List"><code>
 {
@@ -1166,25 +1184,37 @@ is shown as a structured value. This allows more information to be provided, inc
   "description": "A tai chi class intended for beginners",
   "startDate": "2017-03-22T20:00:00-05:00",
   "duration": "PT60M",
-  "activity": {
+  "activity": [{
     "id": "https://www.openactive.io/activity-list/#c16df6ed-a4a0-4275-a8c3-1c8cff56856f",
     "type": "Concept",
     "prefLabel": "Tai Chi",
     "inScheme": "https://www.openactive.io/activity-list/"
-  }
+  }]
 }
 </code>
 </pre>
 
+<p>
 Applications could include additional information, e.g. alternate labels for convenience of consumers.
-
-And, as shown in the earlier example, multiple activities can be specified by specifying an array of objects.
+</p>
 
 ### Categorising events
 
-The [`oa:category`](https://www.openactive.io/ns/#category) property can be used to associate an Event with one or more tags that provide some extra context about an event. This might include general information on the intensity and suitability. While this property can be used to add any arbitrary tags to an Event, a common use case is the need to tag an event as being suitable for a specific type of audience, e.g. Beginners. Where this information is available, the [`oa:level`](https://www.openactive.io/ns/#level) property can be used in preference to [`oa:category`](https://www.openactive.io/ns/#category). 
-
-If an application does not distinguish between different types of tags associated with an Event, then it <em class="rfc2119">SHOULD</em> use the more general [`oa:category`](https://www.openactive.io/ns/#category) property.
+<p>
+The [`oa:category`](https://www.openactive.io/ns/#category) property can be 
+used to associate an Event with one or more tags that provide some extra 
+context about an event. This might include general information on the intensity 
+and suitability. While this property can be used to add any arbitrary tags to 
+an Event, a common use case is the need to tag an event as being suitable for 
+a specific type of audience, e.g. Beginners. Where this information is 
+available, the [`oa:level`](https://www.openactive.io/ns/#level) property 
+can be used in preference to [`oa:category`](https://www.openactive.io/ns/#category). 
+</p>
+<p>
+If an application does not distinguish between different types of tags 
+associated with an Event, then it <em class="rfc2119">SHOULD</em> use the 
+more general [`oa:category`](https://www.openactive.io/ns/#category) property.
+</p>
 
 <pre class="example" title="Tagging an Event"><code>
 {
@@ -1195,24 +1225,41 @@ If an application does not distinguish between different types of tags associate
   "description": "A tai chi class intended for beginners",
   "startDate": "2017-03-22T20:00:00-05:00",
   "duration": "PT60M",
-  "category": ["Suitable for all", "Low intensity"],
-  "level": ["Beginner"]
+  "category": [{
+    "type: "Concept",
+    "prefLabel": "Suitable For All"
+    },
+    {
+    "type: "Concept",
+    "prefLabel": "Low Intensity"
+  }],
+  "level": [{
+    "type: "Concept",
+    "prefLabel": "Beginner"
+  }]
 }
 </code>
 </pre>
 
-Applications publish data using the [`oa:category`](https://www.openactive.io/ns/#category) and [`oa:level`](https://www.openactive.io/ns/#level) properties <em class="rfc2119">MAY</em> use values either from a controlled vocabulary or more free-form user entered labels. 
-
-Where an application is using a controlled vocabulary it <em class="rfc2119">SHOULD</em> publish that vocabulary as structured data.
+<p>
+Where an application is using a controlled vocabulary it 
+<em class="rfc2119">SHOULD</em> publish that vocabulary as structured data.
+</p>
 
 <div class="note">
-In future, the OpenActive Community Group may decide to define and recommend some controlled vocabularies for use in these properties. At present the values of these properties are left deliberately open to encourage publication of open data that may inform future standardisation.
+In future, the OpenActive Community Group may decide to define and recommend 
+some controlled vocabularies for use in these properties. At present the 
+values of these properties are left deliberately open to encourage publication 
+of open data that may inform future standardisation.
 </div>
 
 ### Describing Event Suitability
 
-There are a variety of ways in which the suitability of an event for specific audiences can be expressed. This includes specifying that 
+<p>
+There are a variety of ways in which the suitability of an event for specific 
+audiences can be expressed. This includes specifying that 
 an event is:
+</p>
 
 * suited for a specific age range
 * suited for people with specific levels of experience ([`oa:level`](https://www.openactive.io/ns/#level))
@@ -1220,22 +1267,34 @@ an event is:
 
 #### Age Ranges
 
-Age ranges are specified using the [`oa:ageRange`](https://www.openactive.io/ns/#ageRange) property. The value is a 
-[`schema:QuantifiedValue`](http://schema.org/QuantitativeValue) which should have [minValue](http://schema.org/minValue) or [maxValue](http://schema.org/maxValue) properties. These properties specify an inclusive minimum and maximum age range for participants.
+<p>
+Age ranges are specified using the [`oa:ageRange`](https://www.openactive.io/ns/#ageRange) property. 
+The value is a [`schema:QuantitativeValue`](http://schema.org/QuantitativeValue) 
+which should have [minValue](http://schema.org/minValue) or 
+[maxValue](http://schema.org/maxValue) properties. These properties specify an 
+inclusive minimum and maximum age range for participants.
+</p>
 
-Data publishers using the [`oa:ageRange`](https://www.openactive.io/ns/#ageRange) property MUST ensure that it has:
+<p>
+Data publishers using the [`oa:ageRange`](https://www.openactive.io/ns/#ageRange) 
+property MUST ensure that it has:
+</p>
 
-* a `type` of [`schema:QuantifiedValue`](http://schema.org/QuantitativeValue)
+* a `type` of [`schema:QuantitativeValue`](http://schema.org/QuantitativeValue)
 * at least one of the `minValue` or `maxValue`properties
 
+<p>
 Data consumers SHOULD assume that:
+</p>
 
 * if there is no `ageRange` property for an Event, then the event is suitable for adults only. E.g. as if the `minValue` has been specified as `18`
 * if an `ageRange` is provided without a `minValue` property, then there is no minimum age for the `Event`
 * if an `ageRange` is provided without a `maxValue` property, then there is no maximum age for the `Event`
 * if an `ageRange` is provided with a `minValue` of 0, and there is no `maxValue` property then the Event is suitable for all
 
+<p>
 The following example illustrates how to specify an Event that is suitable for people aged 60 or over.
+</p>
 
 <pre class="example" title="Age range example"><code>
 {
@@ -1244,14 +1303,18 @@ The following example illustrates how to specify an Event that is suitable for p
   "url": "http://www.example.org/events/1",
   "name": "Tai chi Class",
   "ageRange": {
-     "type": "QuantifiedValue",
+     "type": "QuantitativeValue",
      "minValue": 60
   }
 }
 </code>
 </pre>
 
-The following example illustrates an Event that is suitable for all ages. This is indicated by providing an `minValue` property with a value of zero and no `maxValue` property.
+<p>
+The following example illustrates an Event that is suitable for all ages. 
+This is indicated by providing an `minValue` property with a value of zero and 
+no `maxValue` property.
+</p>
 
 <pre class="example" title="Age range - suitable for all example"><code>
 {
@@ -1260,7 +1323,7 @@ The following example illustrates an Event that is suitable for all ages. This i
   "url": "http://www.example.org/events/1",
   "name": "Exercise in the park",
   "ageRange": {
-     "type": "QuantifiedValue",
+     "type": "QuantitativeValue",
      "minValue": 0
   }
 }
@@ -1269,15 +1332,30 @@ The following example illustrates an Event that is suitable for all ages. This i
 
 #### Gender Restriction
 
-Attendance at some events is limited to certain audiences. For example a female only gym class. The [`oa:genderRestriction`](https://www.openactive.io/ns/#genderRestriction) property can be used to specify these restrictions.
+<p>
+Attendance at some events is limited to certain audiences. For example a 
+female only gym class. The [`oa:genderRestriction`](https://www.openactive.io/ns/#genderRestriction) 
+property can be used to specify these restrictions.
+</p>
 
+<p>
 Data publishers using this property MUST use one of the following values:
+</p>
 
 * `https://www.openactive.io/ns#None` indicating that the event has no restrictions
 * `https://www.openactive.io/ns#Male` indicating that the event is restricted to the male gender
 * `https://www.openactive.io/ns#Female` indicating that the event is restricted to the female gender
 
-If the `genderRestriction` property is not supplied for an Event, then data consumers SHOULD NOT assume a default value, the value should be treated as `null`. When searching or filtering for gender restricted Events, data consumers SHOULD remove Events with a `null` value. Invalid values for the `genderRestriction` property SHOULD be treated as `null`.
+<p>
+If the `genderRestriction` property is not supplied for an Event, then data 
+consumers SHOULD NOT assume a default value, the value should be treated as 
+`null`. When searching or filtering for gender restricted Events, data 
+consumers SHOULD remove Events with a `null` value. 
+</p>
+
+<p>
+Invalid values for the `genderRestriction` property SHOULD be treated as `null`.
+</p>
 
 <pre class="example" title="Gender restriction example"><code>
 {
@@ -1290,10 +1368,11 @@ If the `genderRestriction` property is not supplied for an Event, then data cons
 </code>
 </pre>
 
-
 ### Adding programmes
 
-Events can be associated with a Programme using the [`oa:programme`](https://www.openactive.io/ns/#programme) property. In its simplest form this allows the name of a Programme to be associated with an event:
+Events can be associated with a Programme using the 
+[`oa:programme`](https://www.openactive.io/ns/#programme) property. A programme
+is a [`schema:Brand`](http://schema.org/Brand) object.
 
 <pre class="example" title="Tagging an Event"><code>
 {
@@ -1304,25 +1383,8 @@ Events can be associated with a Programme using the [`oa:programme`](https://www
   "description": "A rowing class for beginners",
   "startDate": "2017-04-01T08:00:00Z",
   "duration": "PT60M",
-  "level": ["Beginner"],
-  "programme": "Learn to Row"
-}
-</code>
-</pre>
-
-If more information about the programme is available, then this can be included by describing the Programme in a more structured way:
-
-<pre class="example" title="Tagging an Event"><code>
-{
-  "@context": "https://www.openactive.io/ns/oa.jsonld",
-  "type": "Event",
-  "url": "http://www.example.org/events/1",
-  "name": "Rowing Class",
-  "description": "A rowing class for beginners",
-  "startDate": "2017-04-01T08:00:00Z",
-  "duration": "PT60M",
-  "level": ["Beginner"],
   "programme": {
+    "type": "Brand",
     "name": "Learn to Row",
     "url": "https://www.britishrowing.org/go-rowing/learn-to-row/",
     "description": "Getting started in rowing couldn’t be easier!"
@@ -1340,9 +1402,9 @@ If more information about the programme is available, then this can be included 
 
 This specification relies on some pending changes to Schema.org that will add recurrence rules to Events. The [proposal](https://github.com/schemaorg/schemaorg/pull/1693) has been accepted, but is not yet formally part of the model.
 
-We expect that this proposal will become part of Schema.org in due course. This process will be driven by implementation experience and feedback from the community. 
-On that basis we have included the terms in specification. The following section is written on that basis. However both publishers and consumers should be aware that 
-this is an area that may change in future versions.
+We expect that this proposal will become part of Schema.org in due course. This process will be driven by implementation experience and feedback from the community. On that basis we have included the terms in 
+specification. The following section is written on that basis. However both 
+publishers and consumers should be aware that this is an area that may change in future versions.
 </div>
 
 The following example illustrates basic usage of the [`schema:eventSchedule`](http://pending.schema.org/eventSchedule) property to associate an `Event` with a [`schema:Schedule`](http://pending.schema.org/Schedule). The data describes a Tai Chi class that occurs every Wednesday at 7pm
@@ -1362,7 +1424,8 @@ The following example illustrates basic usage of the [`schema:eventSchedule`](ht
      "repeatFrequency": "P1W",
      "byDay": "http://schema.org/Wednesday",
      "startTime": "19:00Z",
-     "endTime": "20:00Z"
+     "endTime": "20:00Z",
+     "duration": "P1H"
   }  
 }
 </code>
@@ -1370,9 +1433,14 @@ The following example illustrates basic usage of the [`schema:eventSchedule`](ht
 
 ### Describing event availability
 
-Schema.org provides a couple of basic properties for describing the maximum ([`schema:maximumAttendeeCapacity`](http://schema.org/maximumAttendeeCapacity)) and remaining capacity ([`schema:remainingAttendeeCapacity`](http://schema.org/remainingAttendeeCapacity)) for an [`schema:Event`](https://schema.org/Event). 
-
+<p>
+Schema.org provides a couple of basic properties for describing the 
+maximum ([`schema:maximumAttendeeCapacity`](http://schema.org/maximumAttendeeCapacity)) 
+and remaining capacity ([`schema:remainingAttendeeCapacity`](http://schema.org/remainingAttendeeCapacity)) for an [`schema:Event`](https://schema.org/Event). 
+</p>
+<p>
 These properties can be used to provide some basic availability information for scheduled events. These are illustrated in the following example which states that a Tai chi class can be attended by up to 20 people and that there are 4 spaces remaining.
+</p>
 
 <pre class="example" title="Basic event availability"><code>
 {
@@ -1391,18 +1459,26 @@ These properties can be used to provide some basic availability information for 
 
 ### Indicating the status of an event
 
+<p>
 An [`schema:Event`](https://schema.org/Event) may occasionally be rescheduled or cancelled. Schema.org provides the [`schema:eventStatus`](http://schema.org/eventStatus) property for indicating the current status of an event.
+</p>
 
+<p>
 The property can have several standardised values which are defined by the [`schema:EventStatusType`](http://schema.org/EventStatusType) enumeration. The property values should therefore be one of the following URIs:
+</p>
 
 * Cancelled: `http://schema.org/EventCancelled`
 * Postponed: `http://schema.org/EventPostponed`
 * Rescheduled: `http://schema.org/EventRescheduled`
 * Scheduled: `http://schema.org/EventScheduled`
 
+<p>
 If the status property is not provided then applications <em class="rfc2119">SHOULD</em> assume a default value of `http://schema.org/EventScheduled`.
+</p>
 
+<p>
 The following example shows a Tai chi class that has been cancelled:
+</p>
 
 <pre class="example" title="A cancelled event"><code>
 {
@@ -1420,13 +1496,18 @@ The following example shows a Tai chi class that has been cancelled:
 
 ### Describing support for disabilities at events
 
-This specification defines several ways to capture information from organisers about the types of support they provide for people with disabilities 
-or other impairments. This includes: 
+<p>
+This specification defines several ways to capture information from organisers 
+about the types of support they provide for people with disabilities or 
+other impairments. This includes: 
+</p>
 
 * listing the types of disability or impairment that are, or can be accommodated at an event using the [`oa:accessibilitySupport`](https://www.openactive.io/ns/#accessibilitySupport) property
 * providing additional notes for participants using the [`oa:accessibilityInformation`](https://www.openactive.io/ns/#accessibilityInformation) property
 
+<p>
 Examples of using these are shown below:
+</p>
 
 <pre class="example" title="Accessibility information"><code>
 {

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -2184,22 +2184,32 @@ for hire.
   <thead>
     <th>Property</th>
     <th>Status</th>
+    <th>Format</th>
     <th>Notes</th>
   </thead>
   <tbody>  
     <tr>
-      <td>`@id`</td>
+      <td>`@type`</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>Slot</td>
+    </tr> 
+    <tr>
+      <td>`@id`</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>URI</td>
       <td>A URI providing a unique identifier for the resource</td>
     </tr>  
     <tr>
       <td>[`schema:identifier`](http://schema.org/identifier)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Number or String</td>
       <td>A local identifier for the resource</td>
     </tr>  
     <tr>
       <td>[`oa:facilityUse`](https://www.openactive.io/ns/#facilityUse)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
       <td>
       <p>Links a specific Slot with the <code>oa:FacilityUse</code> of which it is a part.
       </p>
@@ -2207,6 +2217,7 @@ for hire.
     <tr>
       <td>[`schema:startDate`](https://schema.org/startDate)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
       <td>
       <p>The start date and time of the slot. Can be specified as a [`schema:Date`](https://schema.org/Date) or
       [`schema:DateTime`](https://schema.org/DateTime).
@@ -2215,6 +2226,7 @@ for hire.
     <tr>
       <td>[`schema:endDate`](https://schema.org/endDate)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>String</td>
       <td>
       <p>
       The end date and time of the event. Can be specified as a [`schema:Date`](https://schema.org/Date) or
@@ -2224,17 +2236,20 @@ for hire.
     <tr>
       <td>[`schema:duration`](https://schema.org/duration)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
       <td>The duration of the event given in [[ISO8601]] format.</td>
     </tr>
     <tr>
       <td>[`schema:offers`](https://schema.org/offers)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of [`schema:Offer`](https://schema.org/Offer)</td>
       <td>Describes offers to book and use this specific slot. If unspecified, then a client SHOULD use offers associated with the 
       related Facility Use.</td>
     </tr>
     <tr>
       <td>[`oa:remainingUses`](https://www.openactive.io/ns/#remainingUses)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>Number</td>
       <td>
       <p>Used to indicate the availability of this Slot. Where a Slot describes the opportunity to use 
       a single facility this property should have a value of 0 or 1. Where a Slot describes the opportunity to 
@@ -2244,6 +2259,7 @@ for hire.
     <tr>
       <td>[`oa:maximumUses`](https://www.openactive.io/ns/#maximumUses)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Number</td>
       <td>
       <p>Where a Slot describes the opportunity to 
       use one of several facilities, which will be allocated during booking, then this value can be used to indicate how 
@@ -2267,53 +2283,69 @@ allow a participant to use that facility for a specified time and duration.
   <thead>
     <th>Property</th>
     <th>Status</th>
+    <th>Format</th>
     <th>Notes</th>
   </thead>
   <tbody>
     <tr>
+      <td>`@type`</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>FacilityUse or IndividualFacilityUse</td>
+    </tr>
+    <tr>
       <td>`@id`</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>URI</td>
       <td>A URI providing a unique identifier for the resource</td>
     </tr>
     <tr>
       <td>[`schema:url`](https://schema.org/url)</td>
+      <td>URL</td>
       <td><em class="rfc2119">REQUIRED</em></td>
       <td>A URL to a web page (or section of a page) that describes the product</td>
     </tr>
     <tr>
       <td>[`schema:identifier`](http://schema.org/identifier)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Number or String</td>      
       <td>A local identifier for the product</td>
     </tr>
     <tr>
       <td>[`schema:name`](https://schema.org/name)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
       <td>The name of the product or service</td>
     </tr>
     <tr>
       <td>[`schema:description`](https://schema.org/description)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
       <td>A free text description of the product or service</td>
     </tr>
     <tr>
       <td>[`schema:image`](https://schema.org/image)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>An image or photo that depicts the product, e.g. a photo of the facility or equipment</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>Array of [`schema:ImageObject`](https://schema.org/ImageObject)</td>
+      <td>One or more images or photos that depicts the facility or equipment</td>
     </tr>
     <tr>
       <td>[`oa:activity`](https://www.openactive.io/ns/#activity)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>Array of [`skos:Concept`](https://www.w3.org/2009/08/skos-reference/skos.html#Concept)</td>
       <td>Specifies the physical activity or activities that can be performed when the facility is used.</td>
     </tr>
     <tr>
       <td>[`schema:location`](https://schema.org/location)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>[`schema:Place`](https://schema.org/Place)</td>
       <td>The location of the facility being used. This will either be a generic location, e.g. a leisure centre or sports hall for equipment or more temporary spaces, or a specific <code>schema:SportsActivityLocation</code> when describing opportunities to use 
       a specific identifiable facility (<code>oa:IndividualFacilityUse</code>)</td>
     </tr>
     <tr>
       <td>[`schema:event`](https://schema.org/events)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>Array of <code>oa:Slot</code></td>
       <td>An array of one or more upcoming slots (<code>oa:Slot</code>) during which the product can be used. E.g. a list of hourly slots during which a 
       football pitch might be hired. Only minimal information need be provided about each event, e.g. identifiers, start time, duration, 
       event status, and any associated offers. This will be sufficient to allow data users to build a timetable of slots, with an availability 
@@ -2322,17 +2354,20 @@ allow a participant to use that facility for a specified time and duration.
     <tr>
       <td>[`schema:offers`](https://schema.org/offers)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>Describes a generic offer to use a facility, e.g to indicate it is available for a set price, or may be used for free. Where offers 
+      <td>Array of [`schema:Offer`](https://schema.org/Offer)</td>
+      <td>Describes one ore more generic offers to use a facility, e.g to indicate it is available for a set price, or may be used for free. Where offers 
       might vary based on time of day (e.g. peak pricing) then this information should be associated with the specific event ("slot")</td>
     </tr>
     <tr>
       <td>[`schema:hoursAvailable`](https://schema.org/hoursAvailable)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of [`schema:OpeningHoursSpecification`](https://schema.org/OpeningHoursSpecification)</td>
       <td>Specifies the hours during which this product is available. The value of this property is a schema:OpeningHoursSpecification.</td>
     </tr>
     <tr>
       <td>[`oa:individualFacilityUses`](https://www.openactive.io/"htns/#individualFacilityUses)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of [`oa:IndividualFacilityUse`](https://www.openactive.io/"htns/#IndividualFacilityUse)</td>
       <td>Links a <code>oa:FacilityUse</code> product, describing a general opportunity to, e.g. book and play tennis at a leisure centre with an array of <code>oa:IndividualFacilityUse</code> products that provide a more detailed description about an opportunity to book, e.g. individual tennis courts. This allows a platform to publish both a general product and time-table as well as more detailed 
       products for individual facilities.</td>
     </tr>

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -1393,19 +1393,113 @@ is a [`schema:Brand`](http://schema.org/Brand) object.
 </code>
 </pre>
 
-### Describing scheduled events
+### Describing event schedules
 
-<div class="note">
-**Schema.org support for recurring events**
-
-**[Issue 2](https://github.com/openactive/modelling-opportunity-data/issues/2)**: Schema.org support for recurring events
-
+<div class="note" title="Schema.org support for recurring events">
+<p>
 This specification relies on some pending changes to Schema.org that will add recurrence rules to Events. The [proposal](https://github.com/schemaorg/schemaorg/pull/1693) has been accepted, but is not yet formally part of the model.
-
-We expect that this proposal will become part of Schema.org in due course. This process will be driven by implementation experience and feedback from the community. On that basis we have included the terms in 
-specification. The following section is written on that basis. However both 
-publishers and consumers should be aware that this is an area that may change in future versions.
+</p>
+<p>We expect that this proposal will become part of Schema.org in due course. This process will be driven by implementation experience and feedback from the community. On that basis we have included the terms in specification. The following section is written on that basis. However both publishers and consumers should be aware that this is an area that may change in future versions.</p>
 </div>
+
+For Events that take place at a regular time it can be useful to publish information 
+about the schedule rather than the individual events. Providing a schedule, rather 
+than a list of individual events means publishing less data and clarifies that 
+each weekly or monthly occurence of an Event is part of a longer series.
+
+The [`schema:eventSchedule`](http://pending.schema.org/eventSchedule) property can 
+be used to describe a [`schema:Schedule`](http://pending.schema.org/Schedule) for 
+an Event.
+
+A Schedule define a repeating calendar entry with sufficient information that 
+future events can be generated from some basic rules.
+
+<table>
+  <thead>
+    <th>Property</th>
+    <th>Status</th>
+    <th>Format</th>
+    <th>Notes</th>
+  </thead>
+  <tbody>  
+    <tr>
+      <td>`@type`</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>`Schedule`</td>
+    </tr>  
+    <tr>
+      <td>[`schema:repeatFrequency`](https://pending.schema.org/repeatFrequency)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>The frequency of the events, specified as an [[ISO8601]] duration, e.g. day, week, month</td>
+    </tr>  
+    <tr>
+      <td>[`schema:startDate`](https://schema.org/startDate)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>Specifies the [`schema:Date`](http://schema.org/Date) from which the schedule 
+      is active</td>
+    </tr>  
+    <tr>
+      <td>[`schema:endDate`](https://schema.org/startDate)</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
+      <td>Specifies the [`schema:Date`](http://schema.org/Date) at which the schedule 
+      ends.</td>
+    </tr>  
+    <tr>
+      <td>[`schema:startTime`](https://schema.org/startTime)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>Specifies the [`schema:Time`](http://schema.org/Time) at which the 
+      Events will take place.</td>
+    </tr>  
+    <tr>
+      <td>[`schema:endTime`](https://schema.org/endTime)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>Specifies the [`schema:Time`](http://schema.org/Time) at which the Events will end</td>
+    </tr> 
+    <tr>
+      <td>[`schema:duration`](https://schema.org/duration)</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
+      <td>Specifies the duration of the Event as an [[ISO8601]] duration.</td>
+    </tr>     
+    <tr>
+      <td>[`schema:byDay`](https://pending.schema.org/byDay)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of [`schema:DayOfWeek`](https://schema.org/DayOfWeek)</td>
+      <td>Lists the day(s) of the week during which the Events will take place.</td>
+    </tr>  
+    <tr>
+      <td>[`schema:byMonth`](https://pending.schema.org/byMonth)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of Integers</td>
+      <td>Lists the month(s) of the year during which the Events will take place. January 
+      is the first month</td>
+    </tr>  
+    <tr>
+      <td>[`schema:byMonthDay`](https://pending.schema.org/byMonthDay)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of Integers</td>
+      <td>Lists the day(s) of the month on which an Event will take place</td>
+    </tr>      
+    <tr>
+      <td>[`schema:repeatCount`](https://pending.schema.org/repeatCount)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Number</td>
+      <td>Specifies that an Event will repeat the specified number of times</td>
+    </tr>
+    <tr>
+      <td>[`schema:exceptDate`](https://pending.schema.org/exceptDate)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of [`Date`](http://schema.org/Date) or [`DateTime`](http://schema.org/DateTime)</td>
+      <td>Defines a list of [`Date`](http://schema.org/Date) or [`DateTime`](http://schema.org/DateTime) during which a scheduled Event will not take place. The property allows exceptions to a Schedule to be specified. If an exception is specified as a [`DateTime`](http://schema.org/DateTime) then only the event that would have started at that specific date and time should be excluded from the schedule. If an exception is specified as a [`Date`](http://schema.org/Date) then any event that is scheduled for that 24 hour period should be excluded from the schedule. This allows a whole day to be excluded from the schedule without having to itemise every scheduled event.</td>
+    </tr>
+  </tbody>   
+</table>
 
 The following example illustrates basic usage of the [`schema:eventSchedule`](http://pending.schema.org/eventSchedule) property to associate an `Event` with a [`schema:Schedule`](http://pending.schema.org/Schedule). The data describes a Tai Chi class that occurs every Wednesday at 7pm
 

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -2110,34 +2110,60 @@ To indicate that a `schema:Event` is only available to paid attendees, opportuni
   <thead>
     <th>Property</th>
     <th>Status</th>
+    <th>Format</th>
     <th>Notes</th>
   </thead>
   <tbody>  
     <tr>
-      <td>`@id`</td>
+      <td>`@type`</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>Offer</td>
+    </tr>
+    <tr>
+      <td>`@id`</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>URI</td>
       <td>A URI providing a unique identifier for the resource</td>
     </tr>
     <tr>
       <td>[`schema:identifier`](http://schema.org/identifier)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Number or String</td>
       <td>A local identifier for the resource</td>
     </tr>  
     <tr>
       <td>[`schema:name`](https://schema.org/name)</td>
-      <td><em class="rfc2119">REQUIRED</em></td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
       <td>The name of the offer suitable for display to participants</td>
     </tr>
     <tr>
+      <td>[`schema:url`](https://schema.org/url)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>URL</td>
+      <td>A URL that a user can click on to start a booking process for this 
+      offer</td>
+    </tr>        
+    <tr>
       <td>[`schema:price`](https://schema.org/price)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>Number</td>
       <td>The offer price available to participants</td>
     </tr>
     <tr>
       <td>[`schema:priceCurrency`](https://schema.org/priceCurrency)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
-      <td>The currency of the offer price.</td>
+      <td>String</td>
+      <td>The currency of the offer price. Specified as a 3-letter ISO 4217 value</td>
     </tr>
+    <tr>
+      <td>[`oa:ageRange`](https://www.openactive.io/ns/#ageRange)</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>[`schema:QuantitativeValue`](https://schema.org/QuantitativeValue)</td>
+      <td>Indicates that an Offer is applicable to a specific age range. Specified as a [QuantitativeValue](http://schema.org/QuantitativeValue) with [minValue](http://schema.org/minValue) and [maxValue](http://schema.org/maxValue) properties. 
+      </td>
+    </tr>    
   </tbody>   
 </table>
 

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -845,23 +845,30 @@ that is separate to its public web page.
 </code>
 </pre>
 
-In the above example the `@id` property provides a unique identifier across the hosting application. But the public URL for the 
-Event uses a separate, customer-specific domain.
+In the above example the `@id` property provides a unique identifier across 
+the hosting application. But the public URL for the Event uses a separate, 
+customer-specific domain.
 
 ## Required and Optional Properties
 
-The following sections include more detail about the properties available to describe each type of resource. Some 
-properties are considered to be essential to ensure the provision of a minimally useful set of information about each 
-resource. These <em class="rfc2119">REQUIRED</em> properties must be provided.
+The following sections include more detail about the properties available to 
+describe each type of resource. Some properties are considered to be essential 
+to ensure the provision of a minimally useful set of information about each 
+resource. These <em class="rfc2119">REQUIRED</em> properties 
+<em class="rfc2119">MUST</em> be provided.
 
-All other properties are considered to be optional but it is <em class="rfc2119">RECOMMENDED</em> that they 
-be provided where possible.
+All other properties are considered to be <em class="rfc2119">OPTIONAL</em>. 
+Some properties have been marked as <em class="rfc2119">RECOMMENDED</em>. 
+Publishers <em class="rfc2119">SHOULD</em> provide these properties if it is 
+feasible to do so, as they will improve the quality and usability of their data.
 
-Data publishers <em class="rfc2119">MAY</em> include additional properties, e.g. from Schema.org or other vocabularies 
-when helpful to describe their data. See the section on **Extending the Model** for more information.
+Data publishers <em class="rfc2119">MAY</em> include additional properties, 
+e.g. from Schema.org or other vocabularies when helpful to describe their data. 
+See the section on **Extending the Model** for more information.
 
-Applications that consume opportunity data <em class="rfc2119">MUST</em> ignore any properties that they don't 
-understand. This allows data publishing practices within the sector to evolve as required.
+Applications that consume opportunity data <em class="rfc2119">MUST</em> ignore 
+any properties that they don't understand. This allows data publishing practices 
+within the sector to evolve as required.
 
 ## Describing Events (<code>schema:Event</code>)
 

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -1034,7 +1034,7 @@ existing Schema.org properties and/or properties defined in the OpenActive Vocab
     </tr>
     <tr>
       <td>[`oa:category`](https://www.openactive.io/ns/#category)</td>
-      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
       <td>Array of [`skos:Concept`](https://www.w3.org/2009/08/skos-reference/skos.html#Concept)</td>
       <td>Provides a set of tags that help categorise and describe an event, e.g. its intensity, purpose, etc.</td>
     </tr>
@@ -2057,6 +2057,12 @@ Both the [`schema:Person`](https://schema.org/Person) and [`schema:Organization`
       <td>Array of [`schema:ImageObject`](https://schema.org/ImageObject)</td>
       <td>Logo for an organization</td>
     </tr>
+    <tr>
+      <td>[`schema:telephone`](https://schema.org/telephone)</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
+      <td>Telephone number of an organization</td>
+    </tr>
 
   </tbody>   
 </table>
@@ -2731,7 +2737,7 @@ that capture additional requirements for the physical activity sector.
 The [[SCHEMA-ORG]] and [[SKOS]] specifications define additional properties 
 that are not directly referenced in this document.
 
-Rather than reflect the whole of these specification in this document, we have 
+Rather than reflect the whole of these specifications in this document, we have 
 chosen to include those types and properties that:
 
 * are necessary to document a basic framework for publishing opportunity data

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -2,7 +2,7 @@
 <html xmlns='http://www.w3.org/1999/xhtml' lang='en'>
   <head>
     <meta charset='utf-8'/>
-    <title>Modelling Opportunity Data 1.1</title>
+    <title>Modelling Opportunity Data 2.0</title>
 
     <script type="text/javascript" class='remove'>
         var respecConfig = {
@@ -19,7 +19,7 @@
           // and its maturity status
           // previousPublishDate:  "1977-03-15",
           previousMaturity:  "ED",
-          previousPublishDate:  "2017-08-10",
+          previousPublishDate:  "2018-07-29",
 
           // if there a publicly available Editor's Draft, this is the link
           edDraftURI:   "https://www.openactive.io/modelling-opportunity-data/EditorsDraft/",
@@ -27,7 +27,7 @@
           //prevED:  "https://www.openactive.io/spec-template/",
           //previousURI:  "https://www.openactive.io/realtime-paged-data-exchange/0.2.3/",
           //testSuiteURI: "https://www.openactive.io/endpoint-validator/",
-          copyrightStart: 2017,
+          copyrightStart: 2018,
 
           // if this is a LCWD, uncomment and set the end of its review period
           // lcEnd: "2009-08-05",
@@ -129,6 +129,11 @@
                 "title": "OpenActive Vocabulary",
                 "publisher": "OpenActive Community Group",            
             },
+            "Open-Booking-API": {
+                "href": "https://www.openactive.io/open-booking-api/EditorsDraft/index.html",
+                "title": "OpenActive Open Booking API",
+                "publisher": "OpenActive Community Group",            
+            },            
             "OpenActive-Activity-List": {
                 "href": "https://www.openactive.io/activity-list/",
                 "title": "OpenActive Activity List",
@@ -139,11 +144,6 @@
     </script>
 
 	<script src='https://www.openactive.io/respec/builds/respec-w3c-common.js' class='remove'></script>
-    <!--
-    <script 
-     src='https://www.w3.org/Tools/respec/respec-w3c-common' 
-     class='remove'></script>
-   -->
 
     <style>
     table {border-collapse: collapse; border: 1px solid #bec9d9}
@@ -200,27 +200,27 @@
     }
     </style>
     <section id='abstract'>
-This specification introduces a data model to support the publication of data describing 
+<p>This specification introduces a data model to support the publication of data describing 
 opportunities for people to engage in physical activities ("opportunity data"). This model 
-covers description of activities, as well as the events and locations in which they take place. 
+covers description of activities, as well as the events and locations in which they take place.</p>
 
-The specification is intended to support the publication of opportunity data as open data 
+<p>The specification is intended to support the publication of opportunity data as open data 
 for anyone to access, use and share. It will also guide reusers of opportunity data, 
-introducing them to the key concepts relevant to that sector.
+introducing them to the key concepts relevant to that sector.</p>
 
-The model may also be useful in guiding the development of both new and existing booking 
-systems and applications that consume opportunity data.
+<p>The model may also be useful in guiding the development of both new and existing booking 
+systems and applications that consume opportunity data.</p>
 
-The specification is an output of the [OpenActive Community Group](http://www.w3.org/community/openactive/) 
-and serves as a common reference point for other specifications and outputs of that activity.
+<p>The specification is an output of the [OpenActive Community Group](http://www.w3.org/community/openactive/) 
+and serves as a common reference point for other specifications and outputs of that activity.</p>
 
-Developers looking for a quick primer on the model and how to use it to structure opportunity data may want to refer to the 
-[[Publishing-Opportunity-Data]] primer which provides a number of additional examples. 
+<p>Developers looking for a quick primer on the model and how to use it to structure opportunity data may want to refer to the 
+[[Publishing-Opportunity-Data]] primer which provides a number of additional examples.</p> 
 
-The data model introduced in this document has been mapped to existing standards and vocabularies, including 
+<p>The data model introduced in this document has been mapped to existing standards and vocabularies, including 
 SKOS ([[SKOS]]) and the Schema.org ([[SCHEMA-ORG]]) types and properties. This existing work provides a 
 useful existing framework around which the 
-[OpenActive Community Group](http://www.w3.org/community/openactive/) can build additional data standards.
+[OpenActive Community Group](http://www.w3.org/community/openactive/) can build additional data standards.</p>
 
     </section>
 
@@ -326,8 +326,11 @@ The following items are therefore out of scope for this specification:
 * personal information, demographics and other information about event participants 
 * APIs for publishing and discovering opportunity data
 
-The [OpenActive Community Group](http://www.w3.org/community/openactive/) may produce 
-additional specifications that address these areas.
+Support for third-party bookings is covered in the draft [[Open-Booking-API]] 
+specification.
+
+The [OpenActive Community Group](http://www.w3.org/community/openactive/) may 
+produce additional specifications that address the other areas.
 
 ## Structure of this document
 
@@ -613,28 +616,6 @@ participants. When participants are looking for opportunities they may be intere
 discovering Events based on either the general activity (e.g. Running) or a specific 
 programme (Back to Netball).
 
-## Activity Opportunities
-
-Not all opportunities to be physically active are organised Events. Some opportunities are self-directed 
-for example: 
-
-* following a designated walking route
-* using a permanent (or temporary) orienteering course
-* going for a ride on a mountain bike trail
-
-The common elements here are that facilities are provided for use at a time of the participants choosing 
-(within limits of opening hours or availability), rather than at a time or schedule specified by the 
-organiser.
-
-However many of the other aspects of describing an [Event](#event) are applicable to describing this 
-type of opportunity. For example:
-
-* they will involve one or more Physical Activities, e.g. mountain biking
-* take place in a location, e.g. "Victoria Park Mountain Bike Trail"
-* have other descriptive attributes, such as suitability for particular types of participants, fitness levels, etc.
-
-In this specification this type of self-guided activities will be referred to as __*Activity Opportunities*__.
-
 ## Offers
 
 Some opportunities are freely available for anyone to attend. Others are only available to members or 
@@ -801,12 +782,6 @@ definitions in SKOS, Schema.org and the OpenActive Vocabulary ([[OpenActive-Voca
       <td>[`skos:Concept`](https://www.w3.org/2009/08/skos-reference/skos.html#Concept)</td>
       <td></td>
     <tr>    
-    <tr>
-      <td>Activity Opportunity</td>
-      <td>[`oa:ActivityOpportunity`](https://www.openactive.io/ns/#ActivityOpportunity)</td>
-      <td>An opportunity to carry out an activity at a location, at a time of the participants 
-      choosing.</td>
-    <tr>
     <tr>
       <td>Offer</td>
       <td>[`schema:Offer`](http://schema.org/Offer)</td>
@@ -2307,18 +2282,6 @@ The community group feels that the data model proposed in this section adequatel
 
 <p></p>
 
-## Describing Activity Opportunities (<code>oa:ActivityOpportunity</code>)
-
-As described earlier in this specification, an [Activity Opportunity](#activity-opportunity) is similar to an Event except it does not take 
-place at a specific time: individual participants will decide when they will take part in the physical activity.
-
-The [`oa:ActivityOpportunity`](https://www.openactive.io/ns/#ActivityOpportunity) type will be used to represent these opportunities. 
-
-Information about Activity Opportunities can be published using the same set of properties that have been identified for [Describing Events](#describing-events-code-schema-event-code-).
-
-However applications <em class="rfc2119">MUST</em> not use the `schema:schedule`, `schema:startDate` and `schema:endDate` properties on this 
-type of resource.
-
 ## Extending the Model
 
 The previous sections describe how to publish opportunity data using a combination of existing and new vocabularies. 
@@ -2336,11 +2299,13 @@ from data publishers, to allow the use of additional properties.
 
 ### Versioning Policy
 
-The broad goal is to ensure that future versions of this specification remain backwards compatible. This will ensure that 
-published data remains valid. 
+The broad goal is to ensure that future versions of this specification 
+remain backwards compatible. This will ensure that published data remains valid. 
 
-New types of resource, relationships and properties can easily be added to extend the model without impacting existing data. 
-Potential breaking changes would include changing the definitions of existing properties, or removing them from the specification.
+New types of resource, relationships and properties can easily be added to 
+extend the model without impacting existing data. Potential breaking changes 
+would include changing the definitions of existing properties, or removing 
+them from the specification.
 
 To avoid this, the goal will be to:
 
@@ -2348,26 +2313,48 @@ To avoid this, the goal will be to:
 * deprecate, rather than remove properties that are judged, based on implementation experience, to be less useful or confusing. Deprecated properties will be clearly marked in both the human and machine-readable versions of the OpenActive namespace.
 * ensure that conformance criteria are loosely defined, balancing the need to be able to validate data against a desire to allow 
 some evolution in practice
+* use version numbering to indicate potential for breaking changes. Minor versions, 
+e.g. 1.1, 2.1, etc should be backwards compatible. Major versions, e.g. 2.0, 3.0 
+are likely to include breaking changes.
 
-Proposed changes to the specification will also be communicated in advance of their formal release, through the sharing of public Editor's Drafts. 
-This will provide opportunities for both publishers and users of the data to update their applications. 
+Proposed changes to the specification will also be communicated in advance of 
+their formal release, through the sharing of public Editor's Drafts. This will 
+provide opportunities for both publishers and users of the data to update their applications. 
 
-To support additional testing and experimentation around new properties, a "beta" namespace has been defined to allow the community to explore 
-extensions to this specification in a controlled way. For more information on the process supporting that see [[OpenActive-Beta-Namespace]].
+To support additional testing and experimentation around new properties, 
+a "beta" namespace has been defined to allow the community to explore extensions 
+to this specification in a controlled way. For more information on the process supporting that see [[OpenActive-Beta-Namespace]].
 
-Regardless of the type of extension, activity can continue to be co-ordinated within the OpenActive Community Group as the primary forum 
-for standardising the publication of opportunity data.
+Regardless of the type of extension, activity can continue to be co-ordinated 
+within the OpenActive Community Group as the primary forum for standardising 
+the publication of opportunity data.
 
 ### Relationship with Schema.org and SKOS
 
-This specification draws heavily on [[SCHEMA-ORG]] and [[SKOS]] to define its core data model. Both of these specifications define additional 
-properties that are not directly referenced in this document.
+This specification draws heavily on [[SCHEMA-ORG]] and [[SKOS]] to define its 
+core data model. This is supplemented with additional custom types and properties 
+that capture additional requirements for the physical activity sector.
 
-However data publishers are free to use any additional types and properties where useful. [[SCHEMA-ORG]] in particular provides a source of a 
-wide range of additional properties for describing Events, Places, Organisations, etc. 
+The [[SCHEMA-ORG]] and [[SKOS]] specifications define additional properties 
+that are not directly referenced in this document.
 
-For example an application may wish to share reviews of events, places or clubs. The [`schema:review`](https://schema.org/review) property 
-and its related data model can be used for this purpose, without requiring revisions to this specification.
+Rather than reflect the whole of these specification in this document, we have 
+chosen to include those types and properties that:
+
+* are necessary to document a basic framework for publishing opportunity data
+* are useful to highlight to encourage consistent usage across the community
+* have stricter conformance rules that used by [[SCHEMA-ORG]]. For example where 
+we have agreed to specific uses of properties to increase quality and consistency 
+in how data is being published
+
+However data publishers are free to use any additional types and properties 
+where useful. [[SCHEMA-ORG]] in particular provides a source of a wide range 
+of additional properties for describing Events, Places, Organisations, etc. 
+
+For example an application may wish to share reviews of events, places or 
+clubs. The [`schema:review`](https://schema.org/review) property and its 
+related data model can be used for this purpose, without requiring revisions 
+to this specification.
 
 ### Defining Custom Vocabularies
 

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -1524,147 +1524,113 @@ Examples of using these are shown below:
 </code>
 </pre>
 
-## Describing Locations (<code>schema:Place</code> and <code>schema:PostalAddress</code>)
+## Describing Locations (<code>schema:Place</code>)
 
-Schema.org takes a flexible approach towards defining the locations for an [`schema:Event`](https://schema.org/Event). 
+This specification recommends use of the [`schema:Place`](https://schema.org/Place) 
+and [`schema:SportsActivityLocation`](https://schema.org/SportsActivityLocation) 
+types for describing locations. 
 
-The legal values for the [`schema:location`](https://schema.org/location) property include:
+The [`schema:location`](https://schema.org/location) property can be used to 
+relate an [`schema:Event`](https://schema.org/Event) 
+or [`oa:FacilityUse`](https://www.openactive.io/ns#FacilityUse) to a Place.
 
-* a simple textual description
-* a [`schema:PostalAddress`](https://schema.org/PostalAddress) 
-* a more fully defined [`schema:Place`](https://schema.org/Place) or one of its sub-types such as a [`schema:CivicStructure`](https://schema.org/CivicStructure) or [`schema:EventVenue`](https://schema.org/EventVenue)
-
-While all three forms are allowed by Schema.org, applications that publish opportunity data <em class="rfc2119">SHOULD</em> either specify a [`schema:PostalAddress`](https://schema.org/PostalAddress) or a more detailed [`schema:Place`](https://schema.org/Place) description.
-
-
-### Describing Addresses
-
-Schema.org provides the following properties for publishing address data using the [`schema:PostalAddress`](https://schema.org/PostalAddress) type.
+The following table lists a number of properties that can be used to 
+describe a [`schema:Place`](https://schema.org/Place) 
 
 <table>
   <thead>
     <th>Property</th>
     <th>Status</th>
-    <th>Notes</th>
-  </thead>
-  <tbody>  
-    <tr>
-      <td>[`schema:streetAddress`](https://schema.org/streetAddress)</td>
-      <td><em class="rfc2119">REQUIRED</em></td>
-      <td>Street address</td>
-    </tr>
-    <tr>
-      <td>[`schema:addressLocality`](https://schema.org/addressLocality)</td>
-      <td><em class="rfc2119">REQUIRED</em></td>
-      <td>Town or other area</td>
-    </tr>
-    <tr>
-      <td>[`schema:region`](https://schema.org/region)</td>
-      <td><em class="rfc2119">REQUIRED</em></td>
-      <td>Region</td>
-    </tr>
-    <tr>
-      <td>[`schema:postalCode`](https://schema.org/postalCode)</td>
-      <td><em class="rfc2119">REQUIRED</em></td>
-      <td>Postcode</td>
-    </tr>
-  </tbody>   
-</table>
-
-The following example shows how to markup a simple address:
-
-<pre class="example" title="An Address">
-<code>
-{
-  "@context": "https://www.openactive.io/ns/oa.jsonld",
-  "type": "PostalAddress",
-  "streetAddress": "North Parade Road",
-  "addressLocality": "Bath",
-  "region": "Somerset",
-  "postalCode": "BA2 4ET"
-}
-</code>
-</pre>
-
-
-### Describing Places
-
-In order to provide additional information, e.g. the name of the location or its geographic co-ordinates, then the [`schema:Place`](https://schema.org/Place) 
-type <em class="rfc2119">MUST</em> be used instead.
-
-The following table lists the properties that can be used to provide descriptions of a [`schema:Place`](https://schema.org/Place) 
-
-<table>
-  <thead>
-    <th>Property</th>
-    <th>Status</th>
+    <th>Format</th>
     <th>Notes</th>
   </thead>
   <tbody>
     <tr>
-      <td>`@id`</td>
+      <td>`@type`</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>A type of Place as defined by Schema.org</td>
+    </tr>
+    <tr>
+      <td>`@id`</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>URI</td>
       <td>A URI providing a unique identifier for the resource</td>
     </tr>
     <tr>
       <td>[`schema:identifier`](http://schema.org/identifier)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>String or Number</td>
       <td>A local identifier for the resource</td>
     </tr>    
     <tr>
       <td>[`schema:url`](https://schema.org/url)</td>
-      <td><em class="rfc2119">REQUIRED</em></td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>URI</td>
       <td>A URL to a web page (or section of a page) that describes the Place</td>
     </tr>
     <tr>
       <td>[`schema:name`](https://schema.org/name)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
       <td>The name of the Place</td>
     </tr>
     <tr>
       <td>[`schema:description`](https://schema.org/description)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
       <td>A free text description of the Place</td>
     </tr>
     <tr>
       <td>[`schema:image`](https://schema.org/image)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>An image or photo that depicts the place</td>
+      <td>Array of [`schema:ImageObject`](https://schema.org/ImageObject)</td>
+      <td>One or more images or photos that depicts the Place</td>
     </tr>
     <tr>
       <td>[`schema:address`](https://schema.org/address)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
-      <td>The street address of the location, expressed as a [`schema:PostalAddress`](https://schema.org/PostalAddress). See the following section for more information on describing [`schema:PostalAddress`](https://schema.org/PostalAddress) resources</td>
+      <td>String or [`schema:PostalAddress`](https://schema.org/PostalAddress)</td>
+      <td>The street address of the location, expressed as a [`schema:PostalAddress`](https://schema.org/PostalAddress).
+      Where possible publishers <em class="rfc2119">MUST</em> specify an address as 
+      an object. Publishers <em class="rfc2119">MUST</em> only use a String value 
+      if they only have a generic location name or free text field, e.g. "In Victoria Park, near the lake"</td>
     </tr>
     <tr>
       <td>[`schema:geo`](https://schema.org/geo)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>[`schema:GeoCoordinates`](https://schema.org/GeoCoordinates)</td>
       <td>The geographic co-ordinates, specified as a latitude and longitude of a Place</td>
     </tr>
     <tr>
       <td>[`schema:containedInPlace`](https://schema.org/containedInPlace)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>[`schema:Place`](https://schema.org/Place)</td>
       <td>Indicates that this Place is part of a larger location. Can be used to allow, e.g. a pitch or other facility to be related to a parent location such as a Leisure Centre</td>
     </tr>
     <tr>
       <td>[`schema:containsPlace`](https://schema.org/containsPlace)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>Relates a Place to other locations and facilities that it contains. Schema.org provides a specific type of Place, called a 
-      [`schema:SportsActivityLocation`](https://schema.org/SportsActivityLocation) for describing facilities</td>
+      <td>Array of [`schema:Place`](https://schema.org/Place)</td>      
+      <td>Relates a Place to one or more other locations and facilities that 
+      it contains.</td>
     </tr>
     <tr>
       <td>[`schema:telephone`](https://schema.org/telephone)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
       <td>A contact telephone number for the location, e.g. for enquiries</td>
     </tr>
     <tr>
       <td>[`schema:openingHoursSpecification`](https://schema.org/openingHoursSpecification)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>Array of [`schema:OpeningHoursSpecification`](http://schema.org/OpeningHoursSpecification)</td>
       <td>Specifies the opening hours of a location. The value of this property is a [`schema:OpeningHoursSpecification`](http://schema.org/OpeningHoursSpecification).</td>
     </tr>
     <tr>
       <td>[`schema:amenityFeature`](https://schema.org/amenityFeature)</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>Array of [`schema:LocationFeatureSpecification`](http://schema.org/LocationFeatureSpecification)</td>
       <td>Used to indicate whether specific amenities are available at a location. The value of this property will be an array of [`schema:LocationFeatureSpecification`](http://schema.org/LocationFeatureSpecification) objects. See "Describing Amenities" for more information.</td>
     </tr>    
   </tbody>   
@@ -1682,8 +1648,9 @@ This example illustrates a simple place description. Building on the previous ex
       "type": "PostalAddress",
       "streetAddress": "North Parade Road",
       "addressLocality": "Bath",
-      "region": "Somerset",
-      "postalCode": "BA2 4ET"
+      "addressRegion": "Somerset",
+      "postalCode": "BA2 4ET",
+      "addressCountry": "UK"
   },
   "telephone": "+44 (0)1225 486905"    
 }
@@ -1701,8 +1668,9 @@ A more precise geographical location can be provided by adding a [`schema:geo`](
       "type": "PostalAddress",
       "streetAddress": "North Parade Road",
       "addressLocality": "Bath",
-      "region": "Somerset",
-      "postalCode": "BA2 4ET"
+      "addressRegion": "Somerset",
+      "postalCode": "BA2 4ET",
+      "addressCountry": "UK"
   },
   "telephone": "+44 (0)1225 486905",
   "geo": {
@@ -1712,6 +1680,73 @@ A more precise geographical location can be provided by adding a [`schema:geo`](
   }
 }
 </code></pre>
+
+### Describing Addresses
+
+Schema.org provides the following properties for publishing address data using the [`schema:PostalAddress`](https://schema.org/PostalAddress) type.
+
+<table>
+  <thead>
+    <th>Property</th>
+    <th>Status</th>
+    <th>Format</th>
+    <th>Notes</th>
+  </thead>
+  <tbody>  
+    <tr>
+      <td>`@type`</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>PostalAddress</td>
+    </tr>  
+    <tr>
+      <td>[`schema:streetAddress`](https://schema.org/streetAddress)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>Street address</td>
+    </tr>
+    <tr>
+      <td>[`schema:addressLocality`](https://schema.org/addressLocality)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>Town or other area</td>
+    </tr>
+    <tr>
+      <td>[`schema:addressRegion`](https://schema.org/addressRegion)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>Region</td>
+    </tr>
+    <tr>
+      <td>[`schema:postalCode`](https://schema.org/postalCode)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>Postcode</td>
+    </tr>
+    <tr>
+      <td>[`schema:addressCountry`](https://schema.org/addressCountry)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>ISO 3166-1 alpha-2 country code</td>
+    </tr>    
+  </tbody>   
+</table>
+
+The following example shows how to markup a simple address:
+
+<pre class="example" title="An Address">
+<code>
+{
+  "@context": "https://www.openactive.io/ns/oa.jsonld",
+  "type": "PostalAddress",
+  "streetAddress": "North Parade Road",
+  "addressLocality": "Bath",
+  "addressRegion": "Somerset",
+  "postalCode": "BA2 4ET",
+  "addressCountry": "UK"
+}
+</code>
+</pre>
 
 ### Describing Amenities
 
@@ -1769,9 +1804,12 @@ In the meantime additional types of amenities can be specified using the more ge
 </code></pre>
 
 
-### Describing Facilities
+### Describing Facilities at a Location
 
-Facilities available at a location can be expressed using the containment properties ([`schema:containedInPlace`](https://schema.org/containedInPlace) and [`schema:containsPlace`](https://schema.org/containsPlace)). The following example illustrates how to describe that a Leisure Centre includes a gym:
+Facilities such as swimming pools, courts, etc available at a location can 
+be expressed using the containment properties 
+([`schema:containedInPlace`](https://schema.org/containedInPlace) 
+and [`schema:containsPlace`](https://schema.org/containsPlace)). The following example illustrates how to describe that a Leisure Centre includes a gym:
 
 <pre class="example" title="Describing a leisure centre"><code>
 {
@@ -1783,14 +1821,15 @@ Facilities available at a location can be expressed using the containment proper
       "type": "PostalAddress",
       "streetAddress": "North Parade Road",
       "addressLocality": "Bath",
-      "region": "Somerset",
-      "postalCode": "BA2 4ET"
+      "addressRegion": "Somerset",
+      "postalCode": "BA2 4ET",
+      "addressCountry": "UK"
   },
-  "containsPlace": {
+  "containsPlace": [{
     "type": "SportsActivityLocation",
     "url": "http://www.better.org.uk/leisure-centre/banes/bath-sports-and-leisure-centre/gym",
     "name": "Gym"
-  }    
+  }]    
 }
 </code></pre>
 
@@ -1824,39 +1863,55 @@ Both the [`schema:Person`](https://schema.org/Person) and [`schema:Organization`
   <thead>
     <th>Property</th>
     <th>Status</th>
+    <th>Format</th>
     <th>Notes</th>
   </thead>
   <tbody>
     <tr>
-      <td>`@id`</td>
+      <td>`@type`</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>Person or Organization</td>
+    </tr>
+    <tr>
+      <td>`@id`</td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>URI</td>
       <td>A URI providing a unique identifier for the resource</td>
     </tr>
     <tr>
       <td>[`schema:identifier`](http://schema.org/identifier)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Number or String</td>
       <td>A local identifier for the resource</td>
     </tr>  
     <tr>
       <td>[`schema:url`](https://schema.org/url)</td>
-      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td><em class="rfc2119">RECOMMENDED</em> for Organization. 
+      <em class="rfc2119">OPTIONAL</em> for Person</td>
+      <td>URL</td>
       <td>A URL to the homepage or other page about the organisation</td>
     </tr>
     <tr>
       <td>[`schema:name`](https://schema.org/name)</td>
-      <td><em class="rfc2119">REQUIRED</em></td>
+      <td><em class="rfc2119">REQUIRED</em> for Organization. 
+      <em class="rfc2119">OPTIONAL</em> for Person</td>
+      <td>String</td>
       <td>The name of the organisation</td>
     </tr>
     <tr>
       <td>[`schema:description`](https://schema.org/description)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>String</td>
       <td>A description of the organisation</td>
     </tr>
     <tr>
       <td>[`schema:logo`](https://schema.org/logo)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
-      <td>The logo of an organisation</td>
+      <td>Array of [`schema:ImageObject`](https://schema.org/ImageObject)</td>
+      <td>Logo for an organization</td>
     </tr>
+
   </tbody>   
 </table>
 
@@ -1871,12 +1926,15 @@ The following example illustrates how to associate an [`schema:Organization`](ht
   "description": "A tai chi class intended for beginners",
   "startDate": "2017-03-22T20:00:00-05:00",
   "duration": "PT60M",
-  "organizer": {
+  "organizer": [{
     "type": "Organization",
     "url": "http://example.org/clubs/1",
     "name": "Bath Tai Chi Club",
-    "logo": "http://www.example.org/clubs/1/logo.png"    
-  }
+    "logo": [{
+        "type": "ImageObject",
+        "url": "http://www.example.org/clubs/1/logo.png"
+    }]    
+  }]
 }
 </code>
 </pre>
@@ -1897,22 +1955,38 @@ The [[OpenActive-Activity-List]] provides an openly licensed standard activity l
   <thead>
     <th>Property</th>
     <th>Status</th>
+    <th>Format</th>
     <th>Notes</th>
   </thead>
   <tbody>
     <tr>
+      <td>`@type`</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>ConceptScheme</td>
+    </tr>
+    <tr>
       <td>`@id`</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>URL</td>      
       <td>A URI providing a unique identifier for the resource</td>
     </tr>
     <tr>
+      <td>[`schema:url`](https://schema.org/url)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>URL</td>
+      <td>A URL that links to the Activity List</td>
+    </tr>    
+    <tr>
       <td>[`dc:title`](http://purl.org/dc/terms/title)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
       <td>Title of the Activity List</td>
     </tr>
     <tr>
       <td>[`schema:description`](https://schema.org/description)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>String</td>
       <td>Description of the activity list</td>
     </tr>
     <tr>
@@ -1920,6 +1994,12 @@ The [[OpenActive-Activity-List]] provides an openly licensed standard activity l
       <td><em class="rfc2119">RECOMMENDED</em></td>
       <td>Reference to the license under which the activity list has been published</td>
     </tr>
+    <tr>
+      <td>[`oa:concepts`](https://www.openactive.org/ns#concepts)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>Array of [`skos:Concept`](https://www.w3.org/2009/08/skos-reference/skos.html#Concept)</td>
+      <td>List of concepts that make up the list</td>
+    </tr>    
   </tbody>   
 </table>
 
@@ -1929,6 +2009,7 @@ The following example illustrates the basic structure of an activity list:
 {
   "@context": "https://www.openactive.io/ns/oa.jsonld",
   "type": "ConceptScheme",
+  "id": "http://www.example.org/activity-list",
   "url": "http://www.example.org/activity-list",
   "title": "Activity List",
   "description": "An example activity list",
@@ -1944,8 +2025,6 @@ The following example illustrates the basic structure of an activity list:
 </code>
 </pre>
 
-The `concepts` property used in the above example is defined in the JSON-LD context published as part of the OpenActive Vocabulary ([[OpenActive-Vocabulary]]).
-
 ### Describing Physical Activities
 
 The following properties from the [[SKOS]] specification can be used to describe physical activities.
@@ -1954,42 +2033,56 @@ The following properties from the [[SKOS]] specification can be used to describe
   <thead>
     <th>Property</th>
     <th>Status</th>
+    <th>Format</th>
     <th>Notes</th>
   </thead>
   <tbody>
     <tr>
+      <td>`@type`</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>Concept</td>
+    </tr>  
+    <tr>
       <td>`@id`</td>
-      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>URI</td>
       <td>A URI providing a unique identifier for the resource</td>
     </tr>  
     <tr>
       <td>[`skos:prefLabel`](https://www.w3.org/2009/08/skos-reference/skos.html#prefLabel)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
       <td>Preferred label for referring to the physical activity. The preferred labels should be used when publishing data about the activities involved in an event.</td>
     </tr>
     <tr>
       <td>[`skos:altLabel`](https://www.w3.org/2009/08/skos-reference/skos.html#altLabel)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Array of String</td>
       <td>Alternative labels for the physical activity</td>
     </tr>
     <tr>
       <td>[`skos:inScheme`](https://www.w3.org/2009/08/skos-reference/skos.html#inScheme)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
+      <td>URI</td>
       <td>Refers to the Activity List in which this physical activity is defined.</td>
     </tr>
     <tr>
       <td>[`skos:broader`](https://www.w3.org/2009/08/skos-reference/skos.html#broader)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>URI</td>
       <td>Where an Activity List is organised as a hierarchy of activities, this property can be used to refer to a parent or broader term. E.g. "Martial Arts" is broader than "Tai Chi".</td>
     </tr>
     <tr>
       <td>[`skos:narrower`](https://www.w3.org/2009/08/skos-reference/skos.html#narrower)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>URI</td>
       <td>Where an Activity List is organised as a hierarchy of activities, this property can be used to refer to a child or narrower term. E.g. "Tai Chi" is a narrower term of "Martial Arts"</td>
     </tr>
     <tr>
       <td>[`skos:notation`](https://www.w3.org/2009/08/skos-reference/skos.html#notation)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>String</td>
       <td>Provides a unique code or identifier for an activity</td>
     </tr>
   </tbody>   

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -2321,14 +2321,6 @@ Proposed changes to the specification will also be communicated in advance of
 their formal release, through the sharing of public Editor's Drafts. This will 
 provide opportunities for both publishers and users of the data to update their applications. 
 
-To support additional testing and experimentation around new properties, 
-a "beta" namespace has been defined to allow the community to explore extensions 
-to this specification in a controlled way. For more information on the process supporting that see [[OpenActive-Beta-Namespace]].
-
-Regardless of the type of extension, activity can continue to be co-ordinated 
-within the OpenActive Community Group as the primary forum for standardising 
-the publication of opportunity data.
-
 ### Relationship with Schema.org and SKOS
 
 This specification draws heavily on [[SCHEMA-ORG]] and [[SKOS]] to define its 
@@ -2358,20 +2350,112 @@ to this specification.
 
 ### Defining Custom Vocabularies
 
-There may be a need for new vocabulary to support the needs of specific applications or user communities. Where these are widely relevant 
-then these extensions might be included in this data model. 
+Individual publishers, or members of the community may identify new requirements 
+for publishing opportunity data that are not covered by this specification or 
+[[SCHEMA-ORG]].
 
-In other circumstances its expected that additional data models and specifications will be produced to support the needs of those 
-communities. For example it may be useful to define standard models for describing the characteristics of cycle tracks or 
-orienteering trails. These would be better defined either as custom vocabularies or proposed as [[SCHEMA-ORG]] extensions. 
+These new requirements might result in:
 
-Where an application or community is defining a custom vocabulary then they <em class="rfc2119">SHOULD</em>:
+* submission of proposals to the OpenActive Community Group for revisions to this 
+specification
+* creation of new specifications that support the needs fo specific types of publisher. 
+For example a group of publishers might wish to define a detailed specification for 
+describing the characteristics of cycle tracks
+* creation of bespoke properties that support the needs of a specific publisher 
+and their data users
 
-* publish documentation that describes the custom properties, types and controlled vocabularies being used
-* create a custom [[JSON-LD]] schema that provides a machine-readable definition of the properties
-* share the documentation and schema with the OpenActive community group
+In all of these cases we encourage discussion of requirements and extensions via 
+the OpenActive Community Group, as the primary forum for standarding the 
+publication of opportunity data.
 
-[[JSON-LD]] allows data to be [published with reference to multiple contexts](https://www.w3.org/TR/json-ld/#advanced-context-usage). This will help clarify for reusers where a dataset is combining this specification with one or more custom vocabularies.
+#### Defining and Using Custom Namespaces
+
+The data model described in this specification is defined in 
+the [OpenActive JSON-LD context](https://www.openactive.io/ns/oa.jsonld) defined by [[OpenActive-Vocabulary]].
+
+They <em class="rfc2119">SHOULD</em> also:
+
+* publish public, human-readable documentation that describes their extension, 
+including any custom properties, types and controlled vocabularies that are 
+being used
+* share the documentation with the OpenActive community group
+* look for opportunities to align their data model with revisions to the  
+standard and other extensions defined in the community
+
+Publish <em class="rfc2119">MUST</em> also
+
+* avoid using names for custom types or properties that clash with the core 
+data model
+* publish a custom [JSON-LD context](https://www.w3.org/TR/json-ld/#the-context) to provide a machine-readable version of their 
+extension 
+* include a reference to their context in their published data
+
+A full tutorial on creating JSON-LD contexts is outside the scope of this specification. 
+
+The following example shows a simple custom JSON-LD context that defines a new namespace
+`ext` and three custom properties.
+
+<pre class="example" title="Example of a custom context"><code>
+{
+   "@context":{
+      "label":"http://www.w3.org/2000/01/rdf-schema#label",
+      "xsd":"http://www.w3.org/2001/XMLSchema#",
+      "ext":"http://example.org/jsonld#",
+      "id":"@id"
+   },
+   "ext:myCustomProperty":{
+      "id":"ext:myCustomProperty",
+      "label":"This is the label"
+   },
+   "ext:myNumericProperty":{
+      "id":"ext:myNumericProperty",
+      "label":"This is a property with a number value",
+      "@type":"xsd:integer"
+   },
+   "ext:myURLProperty":{
+      "id":"ext:myURLProperty",
+      "label":"This is a property with a URI value",
+      "@type":"@id"
+   }
+}
+</code></pre>
+
+[[JSON-LD]] allows data to be [published with reference to multiple contexts](https://www.w3.org/TR/json-ld/#advanced-context-usage). 
+
+Assuming that the previous JSON-LD context was published to `https://example.org/custom.jsonld`, then 
+the following example shows how to use this extension:
+
+<pre class="example" title="Example of a custom context"><code>
+{
+  "@context": [
+    "https://www.openactive.io/ns/oa.jsonld",
+    "https://example.org/custom.jsonld"
+  ],
+  "type": "Event",
+  "ext:myCustomProperty": "foo"
+}
+</code></pre>
+
+Publishers <em class="rfc2119">MUST NOT</em> use unprefixed property and type 
+names.
+
+Using a separate context and prefixed names will help to clarify for users when 
+a dataset is referencing one or more extensions.
+
+#### Beta Namespace
+
+The [[OpenActive-Beta-Namespace]] provides a custom namespace that can be used 
+by publishers experimenting with new properties that are likely to be added to 
+the core specification.
+
+It is defined as a convenience to help document properties that are in active 
+testing and review by the community. Publishers <em class="rfc2119">SHOULD NOT</em> 
+assume that properties in the `beta` namespace will either be added to the core 
+specification or be included in the namespace over the long term.
+
+Publishers needing additional custom properties <em class="rfc2119">SHOULD</em> 
+define their own namespace.
+
   </section>
 
     </section>

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -1423,9 +1423,9 @@ The following example illustrates basic usage of the [`schema:eventSchedule`](ht
      "endDate": "2017-12-31",
      "repeatFrequency": "P1W",
      "byDay": "http://schema.org/Wednesday",
-     "startTime": "19:00Z",
-     "endTime": "20:00Z",
-     "duration": "P1H"
+     "startTime": "19:00",
+     "endTime": "20:00",
+     "duration": "PT1H"
   }  
 }
 </code>
@@ -1650,7 +1650,7 @@ This example illustrates a simple place description. Building on the previous ex
       "addressLocality": "Bath",
       "addressRegion": "Somerset",
       "postalCode": "BA2 4ET",
-      "addressCountry": "UK"
+      "addressCountry": "GB"
   },
   "telephone": "+44 (0)1225 486905"    
 }
@@ -1670,7 +1670,7 @@ A more precise geographical location can be provided by adding a [`schema:geo`](
       "addressLocality": "Bath",
       "addressRegion": "Somerset",
       "postalCode": "BA2 4ET",
-      "addressCountry": "UK"
+      "addressCountry": "GB"
   },
   "telephone": "+44 (0)1225 486905",
   "geo": {
@@ -1743,7 +1743,7 @@ The following example shows how to markup a simple address:
   "addressLocality": "Bath",
   "addressRegion": "Somerset",
   "postalCode": "BA2 4ET",
-  "addressCountry": "UK"
+  "addressCountry": "GB"
 }
 </code>
 </pre>
@@ -1823,7 +1823,7 @@ and [`schema:containsPlace`](https://schema.org/containsPlace)). The following e
       "addressLocality": "Bath",
       "addressRegion": "Somerset",
       "postalCode": "BA2 4ET",
-      "addressCountry": "UK"
+      "addressCountry": "GB"
   },
   "containsPlace": [{
     "type": "SportsActivityLocation",

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -968,7 +968,8 @@ existing Schema.org properties and/or properties defined in the OpenActive Vocab
       <td><em class="rfc2119">RECOMMENDED</em></td>
       <td>String</td>
       <td>The duration of the event given in [[ISO8601]] format. Durations 
-      MUST NOT be zero length. If duration is unknown it should be omitted.</td>
+      MUST NOT be zero length. If duration is unknown it should be omitted. A
+      duration MUST be provided if both a start and end date are available.</td>
     </tr>
     <tr>
       <td>[`schema:location`](https://schema.org/location)</td>
@@ -1030,7 +1031,8 @@ existing Schema.org properties and/or properties defined in the OpenActive Vocab
       <td>[`oa:activity`](https://www.openactive.io/ns/#activity)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
       <td>Array of [`skos:Concept`](https://www.w3.org/2009/08/skos-reference/skos.html#Concept)</td>
-      <td>Specifies one or more physical activities that will take place during an event</td>
+      <td>Specifies one or more physical activities that will take place during an event. 
+      The activities SHOULD ideally be taken from an activity list.</td>
     </tr>
     <tr>
       <td>[`oa:category`](https://www.openactive.io/ns/#category)</td>
@@ -1049,8 +1051,7 @@ existing Schema.org properties and/or properties defined in the OpenActive Vocab
       <td>[`oa:genderRestriction`](https://www.openactive.io/ns/#genderRestriction)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
       <td>[`oa:GenderRestrictionType`](https://www.openactive.io/ns/#GenderRestrictionType)</td>
-      <td>Indicates that an event is restricted to Male, Female or a Mixed audience. Values should be one of the three URIs defined by this specification (see below). If a gender restriction isn't specified then applications 
-      <em class="rfc2119">SHOULD</em> assume that an event is suitable for a mixed audience</td>
+      <td>Indicates that an event is restricted to Male, Female or a Mixed audience. Values should be one of the three URIs defined by this specification (see below).</td>
     </tr>
     <tr>
       <td>[`oa:programme`](https://www.openactive.io/ns/#programme)</td>
@@ -1105,8 +1106,11 @@ existing Schema.org properties and/or properties defined in the OpenActive Vocab
       <td>[`schema:isAccessibleForFree`](https://schema.org/isAccessibleForFree)</td>
       <td><em class="rfc2119">OPTIONAL</em></td>
       <td>Boolean</td>
-      <td>Indicates that an Event is free to attend. Publishers supporting booking <em class="rfc2119">SHOULD</em> also 
-      define a zero priced [`schema:Offer`](https://schema.org/Offer)</td>
+      <td>Indicates that an Event is free to attend. If an Event is bookable in advance, then 
+      publishers <em class="rfc2119">SHOULD</em> also 
+      define a zero priced [`schema:Offer`](https://schema.org/Offer). If the only 
+      [`schema:Offer`](https://schema.org/Offer) for an Event is zero priced, then 
+      publishers SHOULD include this property with a value of `true`.</td>
     </tr>    
     <tr>
       <td>[`oa:isAccessibleWithoutBooking`](https://www.openactive.io/ns/#isAccessibleWithoutBooking)</td>
@@ -1115,7 +1119,9 @@ existing Schema.org properties and/or properties defined in the OpenActive Vocab
       <td>If this is `true` then a participant can turn up and participate on the 
       day. There may also be opportunities for them to book in advance. If the 
       property is `false` then a user MUST book in advance. In this case there 
-      MUST be at least one bookable Offer for the Event.</td>
+      MUST be at least one bookable Offer for the Event. If this property is provided 
+      with a value of `false` then the MUST be at least one applicable Offer with 
+      an `@id` and/or `url` property.</td>
     </tr>    
 
     <tr>
@@ -1188,7 +1194,7 @@ This basic description can be improved by providing information about its locati
 <p>
 The [`oa:activity`](https://www.openactive.io/ns/#activity) property allows an 
 event to be associated with one or more Physical Activities. The Physical 
-Activities used to describe an event may be drawn from a standard Activity 
+Activities used to describe an event SHOULD be drawn from a standard Activity 
 List, e.g. the OpenActive Activity List ([[OpenActive-Activity-List]]). 
 </p>
 
@@ -1385,6 +1391,22 @@ Invalid values for the `genderRestriction` property SHOULD be treated as `null`.
 </code>
 </pre>
 
+<div class="note" title="Request for feedback">
+<p>The community group is aware of both the issues that arise from defining 
+standard terms for gender and the inclusivity issues that might arise from 
+restricting participation in events.</p>
+
+<p>We have standardised these terms to reflect the ways that events are currently 
+described. However there are many additional considerations that relate to how 
+gender is described and the ways that events might be advertised and run in order 
+for people to feel safe and included.</p>
+<p>
+We encourage the community to reflect on the approach outlined here and experiment 
+with alternative options. We have <a href="https://github.com/openactive/modelling-opportunity-data/issues/69#issuecomment-401336335"> outlined some of these options</a> and welcome feedback on how we can improve this area of the specification.
+</p>
+</div>
+
+
 ### Adding programmes
 
 Events can be associated with a Programme using the 
@@ -1483,7 +1505,8 @@ future events can be generated from some basic rules.
       <td><em class="rfc2119">RECOMMENDED</em></td>
       <td>String</td>
       <td>Specifies the duration of the Event as an [[ISO8601]] duration.  Durations 
-      MUST NOT be zero length. If duration is unknown it should be omitted.</td>
+      MUST NOT be zero length. If duration is unknown it should be omitted.  A
+      duration MUST be provided if both a start and end date are available.</td>
     </tr>     
     <tr>
       <td>[`schema:byDay`](https://pending.schema.org/byDay)</td>
@@ -1518,6 +1541,10 @@ future events can be generated from some basic rules.
     </tr>
   </tbody>   
 </table>
+
+While the [`schema:byDay`](https://pending.schema.org/byDay), [`schema:byMonth`](https://pending.schema.org/byMonth) 
+and [`schema:byMonthDay`](https://pending.schema.org/byMonthDay) properties are 
+optional, one of these properties MUST be provided.
 
 The following example illustrates basic usage of the [`schema:eventSchedule`](http://pending.schema.org/eventSchedule) property to associate an `Event` with a [`schema:Schedule`](http://pending.schema.org/Schedule). The data describes a Tai Chi class that occurs every Wednesday at 7pm
 
@@ -1868,6 +1895,9 @@ A more precise geographical location can be provided for a [`schema:Place`](http
   </tbody>   
 </table>
 
+Latitude and longitude values SHOULD be provided to a precision of at least 
+two decimal places in order to be useful to consumers.
+
 The following example illustrates how to use the 
 [`schema:geo`](https://schema.org/geo) property.
 
@@ -2199,7 +2229,9 @@ The following properties from the [[SKOS]] specification can be used to describe
       <td>`@id`</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
       <td>URI</td>
-      <td>A URI providing a unique identifier for the resource</td>
+      <td>A URI providing a unique identifier for the resource. If the activity 
+      is defined in a openly licensed activity list, then publishers SHOULD 
+      provide it's unique identifier.</td>
     </tr>  
     <tr>
       <td>[`skos:prefLabel`](https://www.w3.org/2009/08/skos-reference/skos.html#prefLabel)</td>
@@ -2217,7 +2249,9 @@ The following properties from the [[SKOS]] specification can be used to describe
       <td>[`skos:inScheme`](https://www.w3.org/2009/08/skos-reference/skos.html#inScheme)</td>
       <td><em class="rfc2119">RECOMMENDED</em></td>
       <td>URI</td>
-      <td>Refers to the Activity List in which this physical activity is defined.</td>
+      <td>Refers to the Activity List in which this physical activity is defined. If 
+      an `@id` property is provided then publishers SHOULD provide this property to identify 
+      the activity list which defines the activity.</td>
     </tr>
     <tr>
       <td>[`skos:broader`](https://www.w3.org/2009/08/skos-reference/skos.html#broader)</td>
@@ -2512,7 +2546,8 @@ allow a participant to use that facility for a specified time and duration.
       <td>[`oa:activity`](https://www.openactive.io/ns/#activity)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
       <td>Array of [`skos:Concept`](https://www.w3.org/2009/08/skos-reference/skos.html#Concept)</td>
-      <td>Specifies the physical activity or activities that can be performed when the facility is used.</td>
+      <td>Specifies the physical activity or activities that can be performed when the facility is used. 
+      The activities SHOULD ideally be taken from an activity list.</td>
     </tr>
     <tr>
       <td>[`schema:location`](https://schema.org/location)</td>

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -2187,8 +2187,8 @@ The following example illustrates how to use the
   "telephone": "+44 (0)1225 486905",
   "geo": {
     "type": "GeoCoordinates",
-    "latitude": "51.3816123",
-    "longitude": "-2.3544367"
+    "latitude": 51.3816123,
+    "longitude": -2.3544367
   }
 }
 </code></pre>

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -862,6 +862,12 @@ Some properties have been marked as <em class="rfc2119">RECOMMENDED</em>.
 Publishers <em class="rfc2119">SHOULD</em> provide these properties if it is 
 feasible to do so, as they will improve the quality and usability of their data.
 
+Where data is not available to populate <em class="rfc2119">RECOMMENDED</em> and 
+<em class="rfc2119">OPTIONAL</em> properties, publishers 
+<em class="rfc2119">MUST</em> exclude these from their data. Published data 
+<em class="rfc2119">MUST</em> not include properties with null values, empty 
+strings or empty arrays.
+
 Data publishers <em class="rfc2119">MAY</em> include additional properties, 
 e.g. from Schema.org or other vocabularies when helpful to describe their data. 
 See the section on **Extending the Model** for more information.

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -768,6 +768,11 @@ definitions in SKOS, Schema.org and the OpenActive Vocabulary ([[OpenActive-Voca
       [`schema:EventVenue`](http://schema.org/EventVenue) and [`schema:SportsActivityLocation`](http://schema.org/SportsActivityLocation) which can be used where appropriate</td>
     <tr>
     <tr>
+      <td>Facility Use</td>
+      <td>[`schema:FacilityUse`](http://schema.org/FacilityUse)</td>
+      <td>Products that describe opportunities to use facilities in a location</td>
+    <tr>      
+    <tr>
       <td>Organization</td>
       <td>[`schema:Organization`](https://schema.org/Organization)</td>
       <td>Covers all types of organisations, including companies, clubs, etc</td>
@@ -811,7 +816,7 @@ If there are several different URLs that may be used to identify a resource, it 
 This specification provides three properties for identifying resources:
 
 * `@id` - is used to [assign a globally unique URI to a resource](https://www.w3.org/TR/json-ld/#node-identifiers). This may resolve to further machine-readable 
- information about the resource. When supplied, this URI <em class="rfc2119">MUST</em> be stable and unchanging over time. Applications harvesting and 
+ information about the resource, e.g. as a reference to an API endpoint. When supplied, this URI <em class="rfc2119">MUST</em> be stable and unchanging over time. Applications harvesting and 
  indexing opportunity data <em class="rfc2119">SHOULD</em> use this as the unique identifier for the resource
 * [`schema:url`](http://schema.org/url) - provides a link to a public web page about the resource. Further machine-readable metadata 
 <em class="rfc2119">MAY</em> be discoverable from that web page. Applications <em class="rfc2119">MUST</em> be able to use this URL as a means for providing users with a link to more information about a resource
@@ -823,7 +828,7 @@ In short, the `@id` property provides a unique global identifier, while the `sch
 a public web page about a resource. 
 
 If applicable then publishers may choose to use the same URI for these two properties. If an `@id` property is not provided then 
-applications <em class="rfc2119">MAY</em> choose to rely on the value of this property as a unique identifier.
+applications <em class="rfc2119">MAY</em> choose to rely on the value of the [`schema:url`](http://schema.org/url) property as a unique identifier.
 
 The option to use two different URLs is useful when there is a need to distinguish between a unique identifier and a 
 public resource. For example a platform hosting opportunity data may need to assign a unique identifier to a resource 

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -1535,7 +1535,7 @@ relate an [`schema:Event`](https://schema.org/Event)
 or [`oa:FacilityUse`](https://www.openactive.io/ns#FacilityUse) to a Place.
 
 The following table lists a number of properties that can be used to 
-describe a [`schema:Place`](https://schema.org/Place) 
+describe a [`schema:Place`](https://schema.org/Place).
 
 <table>
   <thead>
@@ -1636,7 +1636,7 @@ describe a [`schema:Place`](https://schema.org/Place)
   </tbody>   
 </table>
 
-This example illustrates a simple place description. Building on the previous example it adds the name, telephone number and website address for the leisure centre:
+The following example illustrates a simple place description including its name, address, telephone number and website.
 
 <pre class="example" title="Describing a leisure centre"><code>
 {
@@ -1653,31 +1653,6 @@ This example illustrates a simple place description. Building on the previous ex
       "addressCountry": "GB"
   },
   "telephone": "+44 (0)1225 486905"    
-}
-</code></pre>
-
-A more precise geographical location can be provided by adding a [`schema:geo`](https://schema.org/geo) property:
-
-<pre class="example" title="Locating a leisure centre"><code>
-{
-  "@context": "https://www.openactive.io/ns/oa.jsonld",
-  "type": "Place",
-  "url": "http://www.better.org.uk/leisure-centre/banes/bath-sports-and-leisure-centre",
-  "name": "Bath Sports and Leisure Centre",
-  "address": {
-      "type": "PostalAddress",
-      "streetAddress": "North Parade Road",
-      "addressLocality": "Bath",
-      "addressRegion": "Somerset",
-      "postalCode": "BA2 4ET",
-      "addressCountry": "GB"
-  },
-  "telephone": "+44 (0)1225 486905",
-  "geo": {
-    "type": "GeoCoordinates",
-    "latitude": "51.3816123",
-    "longitude": "-2.3544367"
-  }
 }
 </code></pre>
 
@@ -1747,6 +1722,65 @@ The following example shows how to markup a simple address:
 }
 </code>
 </pre>
+
+### Describing Geographic Location
+
+A more precise geographical location can be provided for a [`schema:Place`](http://schema.org/Place) by adding a [`schema:geo`](https://schema.org/geo) property. The value of this property is a is a [`schema:GeoCoordinates`](http://schema.org/GeoCoordinates) object.
+
+<table>
+  <thead>
+    <th>Property</th>
+    <th>Status</th>
+    <th>Format</th>
+    <th>Notes</th>
+  </thead>
+  <tbody>  
+    <tr>
+      <td>`@type`</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>String</td>
+      <td>`GeoCoordinates`</td>
+    </tr>  
+    <tr>
+      <td>[`schema:latitude`](https://schema.org/latitude)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>Number</td>
+      <td>Latitude</td>
+    </tr>  
+    <tr>
+      <td>[`schema:longitude`](https://schema.org/longitude)</td>
+      <td><em class="rfc2119">REQUIRED</em></td>
+      <td>Number</td>
+      <td>Longitude</td>
+    </tr>  
+  </tbody>   
+</table>
+
+The following example illustrates how to use the 
+[`schema:geo`](https://schema.org/geo) property.
+
+<pre class="example" title="Locating a leisure centre"><code>
+{
+  "@context": "https://www.openactive.io/ns/oa.jsonld",
+  "type": "Place",
+  "url": "http://www.better.org.uk/leisure-centre/banes/bath-sports-and-leisure-centre",
+  "name": "Bath Sports and Leisure Centre",
+  "address": {
+      "type": "PostalAddress",
+      "streetAddress": "North Parade Road",
+      "addressLocality": "Bath",
+      "addressRegion": "Somerset",
+      "postalCode": "BA2 4ET",
+      "addressCountry": "GB"
+  },
+  "telephone": "+44 (0)1225 486905",
+  "geo": {
+    "type": "GeoCoordinates",
+    "latitude": "51.3816123",
+    "longitude": "-2.3544367"
+  }
+}
+</code></pre>
 
 ### Describing Amenities
 


### PR DESCRIPTION
Started drafting the 2.0 specification.

* Revised all the core models to align with new validation rules and clarified formats of properties
* Removed Activity Opportunity
* Improved extension section to include example of custom context
* Various minor text improvements

Still to do here:

* [x] add tables for subsidiary types, e.g. `GeoCoordinates`
* [x] Fix other bugs
* [x] check that conformance criteria in spreadsheet are clear in spec
* [x] Subtypes of Event and additional rules
* [ ] Add section for url templates 
* [ ] publish initial draft

Still to do elsewhere:

* [x] Add Brand to validation spreadsheet
* [ ] Revise ns to refer to `oa:concept` not `oa:concepts`
* [ ] Review data models to align with spreadsheet, add examples
* [x] File issue about multiple contexts and indicate conformance rules
* [ ] Add `oa:groupFacilityUse` to NS
* [ ] Renamed `individualFacilityUses` in NS
* [ ] Add `isAccessibleWithoutBooking` to NS
* [ ] Renamed `PublicToilets` and `ChangingRooms` in NS
* [ ] Add changes from Schema, e.g. `idTemplate`, `sessionInstanceType`, etc.
