### PR TITLE
Explicit identifier on Brand

### DIFF
--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -1900,7 +1900,7 @@ All of the previous examples of event types provide a means of grouping together
 events:
 
 * `schema:CourseInstance` defines a group of classes
-* `oa:ScheduledSeries` groups together a series of regular events
+* `oa:SessionSeries` groups together a series of regular events
 * `oa:HeadlineEvent` groups together a programme events occuring as part of a large 
 Event
 

--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -1399,6 +1399,13 @@ is a [`schema:Brand`](https://schema.org/Brand) object.
       <td>A URI providing a unique identifier for the resource</td>
     </tr>
     <tr>
+      <td>[`schema:identifier`](https://schema.org/identifier)</td>
+      <td><em class="rfc2119">OPTIONAL</em></td>
+      <td>Number, String, [`schema:PropertyValue`](https://schema.org/PropertyValue) or 
+      an array of [`schema:PropertyValue`](https://schema.org/PropertyValue)</td>
+      <td>A local identifier for the resource.</td>
+    </tr> 
+    <tr>
       <td>[`schema:name`](https://schema.org/name)</td>
       <td><em class="rfc2119">REQUIRED</em></td>
       <td>String</td>


### PR DESCRIPTION
Add "identifier" property to the `Brand` table to make this consistent with the rest of the spec.

Note the spec already specifies that this applies to all types [in 5.3](https://www.openactive.io/modelling-opportunity-data/EditorsDraft/#identifying-and-linking-resources) - this is just ensuring the table is consistent with this for maximum clarity.