### PR TITLE
Consistency of startDate status within Notes

### DIFF
--- a/EditorsDraft/index.html
+++ b/EditorsDraft/index.html
@@ -988,7 +988,7 @@ existing Schema.org properties and/or properties defined in the OpenActive Vocab
       <p>The start date and time of the event. Can be specified as a [`schema:Date`](https://schema.org/Date) or
       [`schema:DateTime`](https://schema.org/DateTime).
       </p>
-      <p>While this property is marked as <em class="rfc2119">OPTIONAL</em>, a data publisher <em class="rfc2119">MUST</em> 
+      <p>While this property is marked as <em class="rfc2119">RECOMMENDED</em>, a data publisher <em class="rfc2119">MUST</em> 
       provide either a [`schema:startDate`](https://schema.org/startDate) or at least one [`schema:eventSchedule`](https://pending.schema.org/eventSchedule) for an event. 
       </td>
     </tr>


### PR DESCRIPTION
Notes for startDate had not been updated to reflect the status of RECOMMENDED (mentions previous status of OPTIONAL). Therefore was contradicting the value in the status column.