### PR TITLE
Add reference to WGS84 for coords

### DIFF
--- a/EditorsDraft/edit.html
+++ b/EditorsDraft/edit.html
@@ -2021,7 +2021,7 @@ A more precise geographical location can be provided for a [schema:Place](https:
 |[schema:latitude](https://schema.org/latitude)|REQUIRED|Number|Latitude|
 |[schema:longitude](https://schema.org/longitude)|REQUIRED|Number|Longitude|
 
-Latitude and longitude values,referenced to the WGS84 coordinate reference system, SHOULD be provided to a precision of at least two decimal places in order to be useful to consumers.
+Latitude and longitude values, referenced to the WGS84 coordinate reference system, SHOULD be provided to a precision of at least two decimal places in order to be useful to consumers.
 
 The following example illustrates how to use the
 [schema:geo](https://schema.org/geo) property.

--- a/EditorsDraft/edit.html
+++ b/EditorsDraft/edit.html
@@ -2013,7 +2013,7 @@ The following example shows how to markup a simple address:
 
 ### Describing Geographic Location
 
-A more precise geographical location can be provided for a [schema:Place](https://schema.org/Place) by adding a [schema:geo](https://schema.org/geo) property. The value of this property is a is a [schema:GeoCoordinates](https://schema.org/GeoCoordinates) object.
+A more precise geographical location can be provided for a [schema:Place](https://schema.org/Place) by adding a [schema:geo](https://schema.org/geo) property. The value of this property is a [schema:GeoCoordinates](https://schema.org/GeoCoordinates) object.
 
 |Property|Status|Format|Notes|
 |--- |--- |--- |--- |
@@ -2021,8 +2021,7 @@ A more precise geographical location can be provided for a [schema:Place](https:
 |[schema:latitude](https://schema.org/latitude)|REQUIRED|Number|Latitude|
 |[schema:longitude](https://schema.org/longitude)|REQUIRED|Number|Longitude|
 
-Latitude and longitude values SHOULD be provided to a precision of at least
-two decimal places in order to be useful to consumers.
+Latitude and longitude values,referenced to the WGS84 coordinate reference system, SHOULD be provided to a precision of at least two decimal places in order to be useful to consumers.
 
 The following example illustrates how to use the
 [schema:geo](https://schema.org/geo) property.


### PR DESCRIPTION
Feedback from the Open Standards Advisory Panel, fixing a typo and specifying a recommended coordinate reference system for latitude and longitude (WGS84).